### PR TITLE
Handle Missing update-notifier Package

### DIFF
--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -30,6 +30,7 @@
 import argparse
 from datetime import datetime
 import os
+import os.path
 import sys
 import urllib2
 
@@ -66,12 +67,20 @@ def add_repo():
 
 
 def apt_get_update():
-    now=datetime.now()
-    apt_cache_age=datetime.fromtimestamp(os.stat('/var/lib/apt/periodic/update-success-stamp').st_mtime)
-    delta = now-apt_cache_age
+    # This section requires that the update-notifier package be installed.
+    update_notifier_file = '/var/lib/apt/periodic/update-success-stamp'
+    notifier_file_exists = os.path.isfile(update_notifier_file)
 
-    if delta.days > 7:
+    if not notifier_file_exists:
+        # No way to check last apt-get update, so we always run.
         os.system('apt-get update')
+    else:
+        # Otherwise only if it hasn't been updated in over 7 days.
+        now = datetime.now()
+        apt_cache_age = datetime.fromtimestamp(os.stat(update_notifier).st_mtime)
+        delta = now - apt_cache_age
+        if delta.days > 7:
+            os.system('apt-get update')
 
 
 def install_dependencies():

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -30,6 +30,7 @@
 import argparse
 from datetime import datetime
 import os
+import os.path
 import sys
 import urllib3
 
@@ -60,12 +61,20 @@ def main():
 
 
 def apt_get_update():
-    now=datetime.now()
-    apt_cache_age=datetime.fromtimestamp(os.stat('/var/lib/apt/periodic/update-success-stamp').st_mtime)
-    delta = now-apt_cache_age
+    # This section requires that the update-notifier package be installed.
+    update_notifier_file = '/var/lib/apt/periodic/update-success-stamp'
+    notifier_file_exists = os.path.isfile(update_notifier_file)
 
-    if delta.days > 7:
+    if not notifier_file_exists:
+        # No way to check last apt-get update, so we always run.
         os.system('apt-get update')
+    else:
+        # Otherwise only if it hasn't been updated in over 7 days.
+        now = datetime.now()
+        apt_cache_age = datetime.fromtimestamp(os.stat(update_notifier).st_mtime)
+        delta = now - apt_cache_age
+        if delta.days > 7:
+            os.system('apt-get update')
 
 
 def install_dependencies():

--- a/linux/ubuntu/14.04/foxpass_setup.sh
+++ b/linux/ubuntu/14.04/foxpass_setup.sh
@@ -32,12 +32,29 @@ BIND_DN="cn=$2,$1"
 BIND_PW=$3
 API_KEY=$4
 
-NOW=`date +%s`
-APT_CACHE_AGE=`stat -c %Z /var/lib/apt/periodic/update-success-stamp`
+# return success if cache is in-date
+# return failure if cache is out of date
+function cache_up_to_date() {
+  local update_notifier_file='/var/lib/apt/periodic/update-success-stamp'
+  if [[ ! -e $update_notifier_file ]]; then
+    return 1
+  else
+    local now=$(date +%s)
+    local apt_cache_age=$(stat -c %Z $update_notifier_file)
+    local time_since_last_update=$((now - apt_cache_age))
+    local seven_days=$((7 * 24 * 3600))
+
+    if [[ time_since_last_update >= seven_days ]]; then
+      return 1
+    else
+      return 0
+    fi
+  fi
+}
 
 # Check for stale content
-if [ $(($NOW-$APT_CACHE_AGE)) -ge 600000 ]; then
-        apt-get update;
+if ! cache_up_to_date; then
+  apt-get update
 fi
 
 # install dependencies, without the fancy ui

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -30,6 +30,7 @@
 import argparse
 from datetime import datetime
 import os
+import os.path
 import sys
 import urllib3
 
@@ -60,12 +61,20 @@ def main():
 
 
 def apt_get_update():
-    now=datetime.now()
-    apt_cache_age=datetime.fromtimestamp(os.stat('/var/lib/apt/periodic/update-success-stamp').st_mtime)
-    delta = now-apt_cache_age
+    # This section requires that the update-notifier package be installed.
+    update_notifier_file = '/var/lib/apt/periodic/update-success-stamp'
+    notifier_file_exists = os.path.isfile(update_notifier_file)
 
-    if delta.days > 7:
+    if not notifier_file_exists:
+        # No way to check last apt-get update, so we always run.
         os.system('apt-get update')
+    else:
+        # Otherwise only if it hasn't been updated in over 7 days.
+        now = datetime.now()
+        apt_cache_age = datetime.fromtimestamp(os.stat(update_notifier).st_mtime)
+        delta = now - apt_cache_age
+        if delta.days > 7:
+            os.system('apt-get update')
 
 
 def install_dependencies():


### PR DESCRIPTION
This commit adds logic to allow the scripts to function even on machines
that do not have the update-notifier package installed.