### PR TITLE
fix undefined variable

### DIFF
--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -71,7 +71,7 @@ def apt_get_update():
     else:
         # Otherwise only if it hasn't been updated in over 7 days.
         now = datetime.now()
-        apt_cache_age = datetime.fromtimestamp(os.stat(update_notifier).st_mtime)
+        apt_cache_age = datetime.fromtimestamp(os.stat(update_notifier_file).st_mtime)
         delta = now - apt_cache_age
         if delta.days > 7:
             os.system('apt-get update')


### PR DESCRIPTION
Looks like an update to the 16.04 bootstrapping script just broke things :)

This is the fix!

```
        apt_cache_age = datetime.fromtimestamp(os.stat(update_notifier).st_mtime)
           NameError: global name 'update_notifier' is not defined
```

Thanks!