### PR TITLE
macOS login hook improvements

### DIFF
--- a/macosx/elcapitan/FoxpassLoginHook.bash
+++ b/macosx/elcapitan/FoxpassLoginHook.bash
@@ -2,7 +2,7 @@
 LOGFILE=/var/log/loginhook.log
 echo "$(date) Login hook exected for user $1" >> $LOGFILE
 
-if [ ! -z "$1" ] && [ ! -d /Users/$1 ]; then
+if [ ! -z "$1" ] && [ "_mbsetupuser" != "$1" ] && [ ! -d /Users/$1 ]; then
   echo "$(date) Adding user $1" >> $LOGFILE
   mkdir -p /Users/$1
   /usr/sbin/chown $1:staff /Users/$1

--- a/macosx/elcapitan/FoxpassLoginHook.bash
+++ b/macosx/elcapitan/FoxpassLoginHook.bash
@@ -1,6 +1,6 @@
 #!/bin/bash
 LOGFILE=/var/log/loginhook.log
-echo "$(date) Login hook exected for user $1" >> $LOGFILE
+echo "$(date) Login hook executed for user $1" >> $LOGFILE
 
 if [ ! -z "$1" ] && [ "_mbsetupuser" != "$1" ] && [ ! -d /Users/$1 ]; then
   echo "$(date) Adding user $1" >> $LOGFILE

--- a/macosx/elcapitan/FoxpassLoginHook.bash
+++ b/macosx/elcapitan/FoxpassLoginHook.bash
@@ -6,4 +6,5 @@ if [ ! -z "$1" ] && [ "_mbsetupuser" != "$1" ] && [ ! -d /Users/$1 ]; then
   echo "$(date) Adding user $1" >> $LOGFILE
   mkdir -p /Users/$1
   /usr/sbin/chown $1:staff /Users/$1
+  /System/Library/CoreServices/ManagedClient.app/Contents/Resources/createmobileaccount -n $1 -v >> $LOGFILE
 fi

--- a/macosx/elcapitan/FoxpassLoginHook.bash
+++ b/macosx/elcapitan/FoxpassLoginHook.bash
@@ -5,5 +5,5 @@ echo "$(date) Login hook exected for user $1" >> $LOGFILE
 if [ ! -z "$1" ] && [ ! -d /Users/$1 ]; then
   echo "$(date) Adding user $1" >> $LOGFILE
   mkdir -p /Users/$1
-  chown $1:staff /Users/$1
+  /usr/sbin/chown $1:staff /Users/$1
 fi

--- a/macosx/elcapitan/FoxpassLoginHook.bash
+++ b/macosx/elcapitan/FoxpassLoginHook.bash
@@ -1,6 +1,9 @@
 #!/bin/bash
+LOGFILE=/var/log/loginhook.log
+echo "$(date) Login hook exected for user $1" >> $LOGFILE
 
 if [ ! -z "$1" ] && [ ! -d /Users/$1 ]; then
+  echo "$(date) Adding user $1" >> $LOGFILE
   mkdir -p /Users/$1
   chown $1:staff /Users/$1
 fi


### PR DESCRIPTION
Here are a couple of improvements:
- Logging to /var/log/loginhook.log
- Added explicit path to /usr/sbin/chown (not in environment, at least on my macOS Sierra installation)
- Ignore parallel invocations for _mbsetupuser during initial setup (iCloud etc.)
- Automatically configure a mobile account for offline login. If FileVault is used, the user still needs to re-enter their password once in the FileVault preferences in order to unlock the system at boot time; after that password updates will be synced.