### PR TITLE
Better sudo fix

### DIFF
--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -150,7 +150,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -148,8 +148,11 @@ def augment_sshd_config():
 # give "wheel" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', 'foxpass-sudo'):
-        with open('/etc/sudoers', "a") as w:
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
 
 def restart():

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -154,6 +154,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     os.system("service sssd restart")

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -151,9 +151,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('/etc/sudoers.d'):
+    if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -148,7 +148,7 @@ def augment_sshd_config():
 # give "wheel" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '\n#includedir'):
+    if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -151,6 +151,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('/etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -148,7 +148,7 @@ def augment_sshd_config():
 # give "wheel" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
+    if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -150,9 +150,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('/etc/sudoers.d'):
+    if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -149,7 +149,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -147,6 +147,14 @@ def augment_sshd_config():
 # give "wheel" group sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', "a") as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    else:
+        if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+            with open('/etc/sudoers.d/95-foxpass-sudo') as w:
+                w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+
 
 def restart():
     os.system("service sssd restart")

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -147,7 +147,7 @@ def augment_sshd_config():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '\n#includedir'):
+    if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -147,7 +147,7 @@ def augment_sshd_config():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
+    if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -144,16 +144,16 @@ def augment_sshd_config():
             w.write("AuthorizedKeysCommandUser\troot\n")
 
 
-# give "wheel" group sudo permissions without password
+# give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '^#includedir'):
-        with open('/etc/sudoers', "a") as w:
+        with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    else:
-        if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
-            with open('/etc/sudoers.d/95-foxpass-sudo') as w:
-                w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+
 
 
 def restart():

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -153,6 +153,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 
 

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -150,6 +150,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('/etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -147,8 +147,11 @@ def augment_sshd_config():
 # give "wheel" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', 'foxpass-sudo'):
-        with open('/etc/sudoers', "a") as w:
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
 
 def restart():

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -150,9 +150,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('/etc/sudoers.d'):
+    if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -153,6 +153,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     os.system("service sssd restart")

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -149,7 +149,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -147,7 +147,7 @@ def augment_sshd_config():
 # give "wheel" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '\n#includedir'):
+    if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -147,7 +147,7 @@ def augment_sshd_config():
 # give "wheel" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
+    if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -150,6 +150,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '^#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('/etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -194,6 +194,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('/etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -197,6 +197,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     # restart nslcd, nscd, ssh

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -57,12 +57,6 @@ def main():
     augment_pam()
     fix_nsswitch()
     fix_sudo()
-
-    # sleep to the next second to make sure sssd.conf has a new timestamp
-    time.sleep(1)
-    # touch the sssd conf file again
-    os.system('touch /etc/sssd/sssd.conf')
-    
     restart()
 
 
@@ -197,8 +191,11 @@ def fix_nsswitch():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', 'foxpass-sudo'):
-        with open('/etc/sudoers', "a") as w:
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
 
 def restart():

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -193,7 +193,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -191,7 +191,7 @@ def fix_nsswitch():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
+    if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -194,9 +194,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('/etc/sudoers.d'):
+    if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -191,10 +191,14 @@ def fix_nsswitch():
 
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
-    os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', 'foxpass-sudo'):
-        with open('/etc/sudoers', "a") as w:
+    os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+
 
 def restart():
     # restart nslcd, nscd, ssh

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -195,6 +195,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('/etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -198,7 +198,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
-
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     # restart nslcd, nscd, ssh

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -192,13 +192,13 @@ def fix_nsswitch():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
-        with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+    #if not file_contains('/etc/sudoers', '^#includedir'):
+    #    with open('/etc/sudoers', 'a') as w:
+    #        w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
-        #os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     # restart nslcd, nscd, ssh

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -198,7 +198,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
-        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
+        #os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     # restart nslcd, nscd, ssh

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -192,9 +192,9 @@ def fix_nsswitch():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    #if not file_contains('/etc/sudoers', '^#includedir'):
-    #    with open('/etc/sudoers', 'a') as w:
-    #        w.write('\n#includedir /etc/sudoers.d')
+    if not file_contains('/etc/sudoers', '\n#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -195,9 +195,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('/etc/sudoers.d'):
+    if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -194,7 +194,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -206,6 +206,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('/etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -202,11 +202,14 @@ def fix_nsswitch():
 
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
-    os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', 'foxpass-sudo'):
-        with open('/etc/sudoers', "a") as w:
+    os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
-
+            
 def restart():
     # restart nslcd, nscd, ssh
     os.system("service nslcd restart")

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -63,7 +63,7 @@ def main():
 def apt_get_update():
     # This section requires that the update-notifier package be installed.
     update_notifier_file = '/var/lib/apt/periodic/update-success-stamp'
-    notifier_file_exists = os.path.isfile(update_notifier_file)
+    notifier_file_exists = os.path.exists(update_notifier_file)
 
     if not notifier_file_exists:
         # No way to check last apt-get update, so we always run.
@@ -206,9 +206,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('/etc/sudoers.d'):
+    if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -203,14 +203,14 @@ def fix_nsswitch():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
+    if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
-        
+
 def restart():
     # restart nslcd, nscd, ssh
     os.system("service nslcd restart")

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -209,7 +209,8 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
-            
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
+        
 def restart():
     # restart nslcd, nscd, ssh
     os.system("service nslcd restart")

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -205,7 +205,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -206,6 +206,8 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isdir('etc/sudoers.d'):
+        os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -209,6 +209,7 @@ def fix_sudo():
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
+        os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")
 
 def restart():
     # restart nslcd, nscd, ssh

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -203,7 +203,7 @@ def fix_nsswitch():
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', '^#includedir'):
+    if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
     if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -205,7 +205,7 @@ def fix_sudo():
     os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
-            w.write('\n#includedir /etc/sudoers.d')
+            w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
     if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -63,7 +63,7 @@ def main():
 def apt_get_update():
     # This section requires that the update-notifier package be installed.
     update_notifier_file = '/var/lib/apt/periodic/update-success-stamp'
-    notifier_file_exists = os.path.isfile(update_notifier_file)
+    notifier_file_exists = os.path.exists(update_notifier_file)
 
     if not notifier_file_exists:
         # No way to check last apt-get update, so we always run.
@@ -206,9 +206,9 @@ def fix_sudo():
     if not file_contains('/etc/sudoers', '\n#includedir'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d')
-    if not os.path.isdir('etc/sudoers.d'):
+    if not os.path.exists('etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
         os.system("chmod 440 /etc/sudoers.d/95-foxpass-sudo")

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -202,9 +202,12 @@ def fix_nsswitch():
 
 # give "sudo" and "foxpass-sudo" groups sudo permissions without password
 def fix_sudo():
-    os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
-    if not file_contains('/etc/sudoers', 'foxpass-sudo'):
-        with open('/etc/sudoers', "a") as w:
+    os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
+    if not file_contains('/etc/sudoers', '^#includedir'):
+        with open('/etc/sudoers', 'a') as w:
+            w.write('\n#includedir /etc/sudoers.d')
+    if not os.path.isfile('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%foxpass-sudo ALL=(ALL:ALL) NOPASSWD:ALL')
 
 def restart():


### PR DESCRIPTION
Many iterations later, I've successfully moved the foxpass-sudo sudo group into it's own file for each distro we currently support.  Script checks for existence of the #includedir line and the 95-foxpass-sudo file, and creates each if they are missing, doing nothing if they exist.