### PR TITLE
Fix sshd_config regex

### DIFF
--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -145,7 +145,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -146,7 +146,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -145,7 +145,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -145,7 +145,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/centos/6.5/foxpass_setup.py
+++ b/linux/centos/6.5/foxpass_setup.py
@@ -31,6 +31,7 @@ import sys
 import time
 import urllib3
 
+
 def main():
     parser = argparse.ArgumentParser(description='Set up Foxpass on a linux host.')
     parser.add_argument('--base-dn', required=True, help='Base DN')
@@ -123,7 +124,8 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
     domain = sssdconfig.get_domain('default')
     domain.add_provider('ldap', 'id')
-    if backup_ldaps: domain.set_option('ldap_backup_uri', ','.join(backup_ldaps))
+    if backup_ldaps:
+        domain.set_option('ldap_backup_uri', ','.join(backup_ldaps))
     domain.set_option('ldap_tls_reqcert', 'demand')
     domain.set_option('ldap_tls_cacert', '/etc/ssl/certs/ca-bundle.crt')
     domain.set_option('ldap_default_bind_dn', bind_dn)
@@ -138,7 +140,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', '^AuthorizedKeysCommand'):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
@@ -158,9 +160,11 @@ def fix_sudo(sudoers):
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) NOPASSWD:ALL'.format(sudo=sudoers))
         os.system('chmod 440 /etc/sudoers.d/95-foxpass-sudo')
 
+
 def restart():
     os.system("service sssd restart")
     os.system("service sshd restart")
+
 
 def file_contains(filename, regex):
     import re
@@ -179,8 +183,9 @@ def is_ec2_host():
     try:
         r = http.request('GET', url)
         return True
-    except:
+    except Exception:
         return False
+
 
 if __name__ == '__main__':
     main()

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -145,7 +145,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -177,7 +177,7 @@ nss_initgroups_ignoreusers ALLLOCAL
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -180,7 +180,7 @@ nss_initgroups_ignoreusers ALLLOCAL
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -188,7 +188,7 @@ nss_initgroups_ignoreusers ALLLOCAL
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -189,7 +189,7 @@ nss_initgroups_ignoreusers ALLLOCAL
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -188,7 +188,7 @@ nss_initgroups_ignoreusers ALLLOCAL
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -188,7 +188,7 @@ nss_initgroups_ignoreusers ALLLOCAL
 
 
 def augment_sshd_config():
-    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand '):
+    if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")


### PR DESCRIPTION
Apply pep8 fixes to centos-6.5 - though we don't support this anymore, so I shouldn't have bothered.

Also, tested.