### PR TITLE
Rewrite foxpass sudo

### DIFF
--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -159,10 +159,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -44,6 +44,7 @@ def main():
     parser.add_argument('--api-url', '--api', default='https://api.foxpass.com', help='API Url')
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -153,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -154,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -159,9 +159,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -155,13 +155,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -160,9 +160,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -44,6 +44,7 @@ def main():
     parser.add_argument('--api-url', '--api', default='https://api.foxpass.com', help='API Url')
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -154,13 +155,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -160,10 +160,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -159,10 +159,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -44,6 +44,7 @@ def main():
     parser.add_argument('--api-url', '--api', default='https://api.foxpass.com', help='API Url')
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -153,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -154,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -159,9 +159,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -44,6 +44,7 @@ def main():
     parser.add_argument('--api-url', '--api', default='https://api.foxpass.com', help='API Url')
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -153,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -154,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -159,10 +159,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -44,6 +44,7 @@ def main():
     parser.add_argument('--api-url', '--api', default='https://api.foxpass.com', help='API Url')
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -153,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -60,7 +60,7 @@ def main():
     run_authconfig(args.ldap_uri, args.base_dn)
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -154,13 +154,13 @@ def augment_sshd_config():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -159,9 +159,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -65,7 +65,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
     restart()
 
 

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -207,10 +207,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -65,7 +65,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     restart()
 
 
@@ -202,13 +202,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -46,6 +46,7 @@ def main():
     parser.add_argument('--ldap-connections', default=2, type=int, help='Number of connections to make to LDAP server.')
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -201,13 +202,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -207,9 +207,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -65,7 +65,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
     restart()
 
 

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -45,6 +45,7 @@ def main():
     parser.add_argument('--ldap-connections', default=2, type=int, help='Number of connections to make to LDAP server.')
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -204,13 +205,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -210,10 +210,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -210,9 +210,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -65,7 +65,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     restart()
 
 
@@ -205,13 +205,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -45,6 +45,7 @@ def main():
     parser.add_argument('--ldap-connections', default=2, type=int, help='Number of connections to make to LDAP server.')
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -212,13 +213,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -64,7 +64,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     restart()
 
 
@@ -213,13 +213,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -218,9 +218,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -218,10 +218,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -64,7 +64,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
     restart()
 
 

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -65,7 +65,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
     restart()
 
 

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -219,10 +219,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -46,6 +46,7 @@ def main():
     parser.add_argument('--ldap-connections', default=2, type=int, help='Number of connections to make to LDAP server.')
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -213,13 +214,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -219,9 +219,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -65,7 +65,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     restart()
 
 
@@ -214,13 +214,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -45,6 +45,7 @@ def main():
     parser.add_argument('--ldap-connections', default=2, type=int, help='Number of connections to make to LDAP server.')
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -212,13 +213,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -64,7 +64,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     restart()
 
 
@@ -213,13 +213,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -218,9 +218,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -218,10 +218,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -64,7 +64,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
     restart()
 
 

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -45,6 +45,7 @@ def main():
     parser.add_argument('--ldap-connections', default=2, type=int, help='Number of connections to make to LDAP server.')
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
+    parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw',
                         default=False,
                         action='store_true',
@@ -212,13 +213,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -64,7 +64,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     restart()
 
 
@@ -213,13 +213,13 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoer):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoer:
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo') or update_sudoers:
         with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
             w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -218,9 +218,10 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -218,10 +218,9 @@ def fix_sudo(sudoers, require_sudoers_pw):
             w.write('\n#includedir /etc/sudoers.d\n')
     if not os.path.exists('/etc/sudoers.d'):
         os.system('mkdir /etc/sudoers.d && chmod 750 /etc/sudoers.d')
-    if not os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
-        with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
-            w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
-                    format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
+    with open('/etc/sudoers.d/95-foxpass-sudo', 'w') as w:
+        w.write('# Adding Foxpass group to sudoers\n%{sudo} ALL=(ALL:ALL) {command}'.
+                format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -64,7 +64,7 @@ def main():
     augment_sshd_config()
     augment_pam()
     fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoer)
     restart()
 
 


### PR DESCRIPTION
Change in philosophy per customer request (https://app.intercom.io/a/apps/on8m5jmk/inbox/inbox/740341/conversations/18468756641)

Always overwrite /etc/sudoers.d/95-foxpass-sudo
Possible downside: runnning the command without the --sudoers-group will revert the group to 'foxpass-sudo' and may create un-intended consequences.
Proposed Solution: re-do all of the output for the script to inform users of changes made by script.  NOTE: this is a large output change.