### PR TITLE
fix centos 8 sssd permission error

### DIFF
--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -66,6 +66,7 @@ def main():
     time.sleep(1)
     # touch the sssd conf file again
     os.system('touch /etc/sssd/conf.d/authconfig-sssd.conf')
+    os.system('chmod 600 /etc/sssd/conf.d/authconfig-sssd.conf')
 
     restart()
 


### PR DESCRIPTION
## Description of the change

Fix the permission related to sssd configuration, the exact error is 
`Config merge error: File /etc/sssd/conf.d/authconfig-sssd.conf did not pass access check. Skipping.`

## Type of change
- [x] Bug fix
- [ ] New feature

### Testing

- [ ] Testing information has been added - test cases checklist and steps followed for testing.
- [ ] Testing screenshot(s) attached for more information.

## Security

- [ ] This PR has security related considerations.