### PR TITLE
update script grep special characters

### DIFF
--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -87,12 +87,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -102,12 +102,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -87,12 +87,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -102,12 +102,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -86,12 +86,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -101,12 +101,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -86,12 +86,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -101,12 +101,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/centos/6.5/foxpass_setup.py
+++ b/linux/centos/6.5/foxpass_setup.py
@@ -80,12 +80,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`uname -n`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -95,12 +95,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/centos/6.5/foxpass_setup.sh
+++ b/linux/centos/6.5/foxpass_setup.sh
@@ -37,12 +37,12 @@ yum install -y sssd authconfig
 
 # write to foxpass_ssh_keys.sh
 cat > /usr/local/bin/foxpass_ssh_keys.sh <<"EOF"
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="__API_KEY__"
 hostname=$(uname -n)
-if grep -q "^${user}:" /etc/passwd; then exit 1; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
 curl -q -m 5 -f "https://api.foxpass.com/sshkeys/?secret=${secret}&user=${user}&hostname=${hostname}" 2>/dev/null
 

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -86,12 +86,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -101,12 +101,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`uname -n`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/centos/7/foxpass_setup.sh
+++ b/linux/centos/7/foxpass_setup.sh
@@ -37,12 +37,12 @@ yum install -y sssd authconfig
 
 # write to foxpass_ssh_keys.sh
 cat > /usr/local/bin/foxpass_ssh_keys.sh <<"EOF"
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="__API_KEY__"
 hostname=$(uname -n)
-if grep -q "^${user}:" /etc/passwd; then exit 1; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
 curl -q -m 5 -f "https://api.foxpass.com/sshkeys/?secret=${secret}&user=${user}&hostname=${hostname}" 2>/dev/null
 

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -87,12 +87,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -102,12 +102,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`uname -n`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -94,12 +94,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -109,12 +109,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/debian/7/foxpass_setup.sh
+++ b/linux/debian/7/foxpass_setup.sh
@@ -43,12 +43,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y curl libnss-ldapd nscd nslcd
 
 # write to foxpass_ssh_keys.sh
 cat > /foxpass_ssh_keys.sh <<"EOF"
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="__API_KEY__"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit 1; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
 curl -q -m 5 -f "https://api.foxpass.com/sshkeys/?secret=${secret}&user=${user}&hostname=${hostname}" 2>/dev/null
 

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -94,12 +94,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -109,12 +109,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -94,12 +94,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -109,12 +109,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -97,12 +97,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -112,12 +112,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/12.04/foxpass_setup.sh
+++ b/linux/ubuntu/12.04/foxpass_setup.sh
@@ -41,12 +41,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y openssh-server
 
 # write to foxpass_ssh_keys.sh
 cat > /usr/local/bin/foxpass_ssh_keys.sh <<"EOF"
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="__API_KEY__"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit 1; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
 curl -q -m 5 -f "https://api.foxpass.com/sshkeys/?secret=${secret}&user=${user}&hostname=${hostname}" 2>/dev/null
 

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -105,12 +105,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -120,12 +120,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/14.04/foxpass_setup.sh
+++ b/linux/ubuntu/14.04/foxpass_setup.sh
@@ -51,12 +51,12 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y curl libnss-ldapd nscd nslcd
 
 # write to foxpass_ssh_keys.sh
 cat > /usr/local/bin/foxpass_ssh_keys.sh <<"EOF"
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="__API_KEY__"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit 1; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
 curl -q -m 5 -f "https://api.foxpass.com/sshkeys/?secret=${secret}&user=${user}&hostname=${hostname}" 2>/dev/null
 

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -106,12 +106,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -121,12 +121,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -105,12 +105,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -120,12 +120,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -105,12 +105,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -120,12 +120,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -106,12 +106,12 @@ def write_foxpass_ssh_keys_script(apis, api_key):
             append = '&aws_instance_id=${aws_instance_id}&aws_region_id=${aws_region_id}" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -121,12 +121,12 @@ exit $?
             append = '" 2>/dev/null'
             curls = [curl + append for curl in curls]
             contents = """\
-#!/bin/sh
+#!/bin/bash
 
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """


### PR DESCRIPTION
## Description of the change

updated the foxpass_ssh_keys.sh to grep for users with special chars

## Type of change
- [x] Bug fix
- [ ] New feature

### Testing

- [x] Testing information has been added - test cases checklist and steps followed for testing.
- [ ] Testing screenshot(s) attached for more information.

## Security

- [ ] This PR has security related considerations.


--Tests

echo "user_name:1
user.name:2
not_user_name:3" > tests
USER=user.name
grep "^${USER/./\\.}:" tests
user.name:2
