### PR TITLE
Turn on pam and nss so password-based logins with LDAP will still work

### DIFF
--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -129,6 +129,10 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
     sssdconfig = SSSDConfig()
     sssdconfig.import_config('/etc/sssd/conf.d/authconfig-sssd.conf')
 
+    sssdconfig.new_service('pam')
+    sssdconfig.new_service('nss')
+    sssdconfig.activate_service('pam')
+    sssdconfig.activate_service('nss')
     domain = sssdconfig.get_domain('default')
     domain.add_provider('ldap', 'id')
     if backup_ldaps:


### PR DESCRIPTION
## Description of the change

Without the pam and nss service enabled in sssd, the pam cannot use sssd to check passwords against LDAP at log-in.

## Type of change
- [X] Bug fix
- [ ] New feature

### Testing

- [X] Testing information has been added - test cases checklist and steps followed for testing.
- [ ] Testing screenshot(s) attached for more information.

## Security

- [ ] This PR has security related considerations.

Testing:
Spin up Centos 8 machine
Download and run this foxpass_setup.py script
1. make sure ssh-key based logins still work
2. enable password-based logins in /etc/ssh/sshd_config and then attempt to log in using name/password.