### PR TITLE
activate foxpass sudoers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # foxpass-setup
 Scripts for setting up Foxpass integration in common environments
+
+# Run docker images
+## Build ubuntu image (Testing purposes only)
+
+`docker build -f docker/Docker_ubuntu1804 -t docker_ubuntu1804 .`
+
+## Run ubuntu image (Testing purposes only)
+
+`docker run --rm -e API_KEY={API_KEY} -e BASE_DN={BASE_DN} -e BIND_USER={BIND_USER} -e BIND_PASSWORD={BIND_PASSWORD} -ti docker_ubuntu1804`
+
+See the available [Dockerfiles](https://github.com/foxpass/foxpass-setup/tree/master/docker).

--- a/docker/Docker_amazonlinux2
+++ b/docker/Docker_amazonlinux2
@@ -1,0 +1,16 @@
+FROM amazonlinux:2
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN yum -y update && yum -y install epel-release python-pip openssh-server sudo
+#RUN yum --enablerepo=epel install -y python-pip
+RUN python -m pip install urllib3
+
+COPY linux/amzn/2.0/foxpass_setup.py /
+
+ENTRYPOINT python foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_amazonlinux2
+++ b/docker/Docker_amazonlinux2
@@ -5,12 +5,10 @@ ARG BASE_DN
 ARG BIND_USER
 ARG BIND_PASSWORD
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 RUN yum -y update && yum -y install epel-release python-pip openssh-server sudo
 #RUN yum --enablerepo=epel install -y python-pip
 RUN python -m pip install urllib3
 
 COPY linux/amzn/2.0/foxpass_setup.py /
 
-ENTRYPOINT python foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug
+ENTRYPOINT python foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_centos7
+++ b/docker/Docker_centos7
@@ -5,12 +5,10 @@ ARG BASE_DN
 ARG BIND_USER
 ARG BIND_PASSWORD
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 RUN yum -y update && yum -y install epel-release openssh-server sudo
 RUN yum --enablerepo=epel install -y python-pip
 RUN python -m pip install urllib3
 
 COPY linux/centos/7/foxpass_setup.py /
 
-ENTRYPOINT python foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug
+ENTRYPOINT python foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_centos7
+++ b/docker/Docker_centos7
@@ -1,0 +1,16 @@
+FROM centos:7
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN yum -y update && yum -y install epel-release openssh-server sudo
+RUN yum --enablerepo=epel install -y python-pip
+RUN python -m pip install urllib3
+
+COPY linux/centos/7/foxpass_setup.py /
+
+ENTRYPOINT python foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_centos8
+++ b/docker/Docker_centos8
@@ -1,0 +1,15 @@
+FROM centos:8
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN yum -y update && yum -y install python3-pip openssh-server sudo
+RUN pip3 install urllib3
+
+COPY linux/centos/8/foxpass_setup.py /
+
+ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_centos8
+++ b/docker/Docker_centos8
@@ -5,11 +5,9 @@ ARG BASE_DN
 ARG BIND_USER
 ARG BIND_PASSWORD
 
-ENV DEBIAN_FRONTEND=noninteractive
-
 RUN yum -y update && yum -y install python3-pip openssh-server sudo
 RUN pip3 install urllib3
 
 COPY linux/centos/8/foxpass_setup.py /
 
-ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug
+ENTRYPOINT python3 foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_debian10
+++ b/docker/Docker_debian10
@@ -8,8 +8,8 @@ ARG BIND_PASSWORD
 ENV DEBIAN_FRONTEND=noninteractive 
 
 RUN apt-get -y update && apt-get -y install python3-pip openssh-server sudo
-RUN pip install urllib3
+RUN pip3 install urllib3
 
 COPY linux/debian/10/foxpass_setup.py /
 
-ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug
+ENTRYPOINT python3 foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --debug

--- a/docker/Docker_debian10
+++ b/docker/Docker_debian10
@@ -1,0 +1,15 @@
+FROM debian:10
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive 
+
+RUN apt-get -y update && apt-get -y install python3-pip openssh-server sudo
+RUN pip install urllib3
+
+COPY linux/debian/10/foxpass_setup.py /
+
+ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_debian9
+++ b/docker/Docker_debian9
@@ -12,4 +12,4 @@ RUN pip3 install urllib3
 
 COPY linux/debian/9/foxpass_setup.py /
 
-ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --debug
+ENTRYPOINT python3 foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --debug

--- a/docker/Docker_debian9
+++ b/docker/Docker_debian9
@@ -1,0 +1,15 @@
+FROM debian:9
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -y update && apt-get -y install python3-pip openssh-server sudo
+RUN pip3 install urllib3
+
+COPY linux/debian/9/foxpass_setup.py /
+
+ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --debug

--- a/docker/Docker_ubuntu1804
+++ b/docker/Docker_ubuntu1804
@@ -1,0 +1,16 @@
+FROM ubuntu:18.04
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive 
+
+RUN apt-get -y update && apt-get -y install python3-pip openssh-server sudo
+RUN pip3 install urllib3
+RUN echo 'root:root' | chpasswd
+
+COPY linux/ubuntu/18.04/foxpass_setup.py /
+
+ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_ubuntu1804
+++ b/docker/Docker_ubuntu1804
@@ -13,4 +13,4 @@ RUN echo 'root:root' | chpasswd
 
 COPY linux/ubuntu/18.04/foxpass_setup.py /
 
-ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug
+ENTRYPOINT python3 foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_ubuntu2004
+++ b/docker/Docker_ubuntu2004
@@ -1,0 +1,16 @@
+FROM ubuntu:20.04
+
+ARG API_KEY
+ARG BASE_DN
+ARG BIND_USER
+ARG BIND_PASSWORD
+
+ENV DEBIAN_FRONTEND=noninteractive 
+
+RUN apt-get -y update && apt-get -y install python3-pip openssh-server sudo
+RUN pip install urllib3
+RUN echo 'root:root' | chpasswd
+
+COPY linux/ubuntu/20.04/foxpass_setup.py /
+
+ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug

--- a/docker/Docker_ubuntu2004
+++ b/docker/Docker_ubuntu2004
@@ -13,4 +13,4 @@ RUN echo 'root:root' | chpasswd
 
 COPY linux/ubuntu/20.04/foxpass_setup.py /
 
-ENTRYPOINT python3 foxpass_setup.py --base-dn {BASE_DN} --bind-user {BIND_USER} --bind-pw {BIND_PW} --api-key {API_KEY} --enable-ldap-sudoers --debug
+ENTRYPOINT python3 foxpass_setup.py --base-dn ${BASE_DN} --bind-user ${BIND_USER} --bind-pw ${BIND_PASSWORD} --api-key ${API_KEY} --enable-ldap-sudoers --debug

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -199,8 +199,8 @@ def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_ref
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    augment_openldap(base_dn)
-    augment_nsswitch()
+    augment_openldap(base_dn, debug)
+    augment_nsswitch(debug)
 
     if debug:
         to_file = open_file('/etc/sssd/sssd.conf')

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -46,10 +46,12 @@ def main():
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--keep-command', default=False, action='store_true', help='Do not replace sshd key command')
-    parser.add_argument('--require-sudoers-pw',
-                        default=False,
-                        action='store_true',
-                        help='set sudoers default password requirement')
+    parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    # Foxpass SUDOers add-on
+    parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
+    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_time parameter')
+    parser.add_argument('--full-refresh-interval', default=21600, help='In hours, default is 6 hours')
+    parser.add_argument('--smart-refresh-interval', default=900, help='In minutes, default is 15 minutes')
 
     args = parser.parse_args()
 
@@ -62,6 +64,9 @@ def main():
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config(args.keep_command)
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+
+    if args.enable_ldap_sudoers:
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -146,6 +151,32 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
     sssdconfig.write()
 
 
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
+    from SSSDConfig import SSSDConfig
+    sssdconfig = SSSDConfig()
+    sssdconfig.import_config('/etc/sssd/sssd.conf')
+
+    try:
+        sssdconfig.new_service('sudo')
+        sssdconfig.activate_service('sudo')
+    except:
+        pass
+
+    domain = sssdconfig.get_domain('default')
+    domain.add_provider('ldap', 'sudo')
+    domain.set_option('ldap_sudo_search_base', 'ou=SUDOers,{}'.format(base_dn))
+    domain.set_option('ldap_sudo_full_refresh_interval', full_refresh_interval)
+    domain.set_option('ldap_sudo_smart_refresh_interval', smart_refresh_interval)
+
+    sssdconfig.activate_service('sudo')
+    sssdconfig.set('sudo', 'sudo_timed', str(sudo_timed).lower())
+    sssdconfig.save_domain(domain)
+    sssdconfig.write()
+
+    augment_openldap(base_dn)
+    augment_nsswitch()
+
+
 def augment_sshd_config(keep_command):
     sshd_config_file = '/etc/ssh/sshd_config'
     key_command = 'AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n'
@@ -159,6 +190,18 @@ def augment_sshd_config(keep_command):
     else:
         print 'AuthorizedKeysCommand already set, will not use Foxpass for ssh key verification'
         return
+
+
+def augment_openldap(bind_dn):
+    if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
+        with open('/etc/openldap/ldap.conf', "a") as w:
+            w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
+
+
+def augment_nsswitch():
+    if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
+        with open('/etc/nsswitch.conf', "a") as w:
+            w.write("sudoers: files sss")
 
 
 def write_authorizedkeyscommand(sshd_config_file, key_command, key_command_user):

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -26,6 +26,7 @@
 
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -61,14 +61,14 @@ def main():
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         sssd_path = '/etc/sssd/sssd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
-        ldap_path = open_file('/etc/openldap/ldap.conf')
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        ldap_path = '/etc/openldap/ldap.conf'
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_sssd = open_file(sssd_path)
@@ -88,7 +88,7 @@ def main():
     if args.enable_ldap_sudoers:
         configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_sssd = open_file(sssd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -26,6 +26,7 @@
 
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys
@@ -46,12 +47,13 @@ def main():
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    parser.add_argument('--opt-timeout', default=6, help='option to set the sssd opt timeout')
+    parser.add_argument('--debug', default=False, action='store_true', help='Turn on debug mode')
     # Foxpass SUDOers add-on
     parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
-    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_time parameter')
+    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_timed parameter')
     parser.add_argument('--full-refresh-interval', default=21600, help='In hours, default is 6 hours')
     parser.add_argument('--smart-refresh-interval', default=900, help='In minutes, default is 15 minutes')
-    parser.add_argument('--opt-timeout', default=6, help='option to set the sssd opt timeout')
 
     args = parser.parse_args()
 
@@ -59,14 +61,14 @@ def main():
     apis = [args.api_url] + args.apis
 
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key)
-    run_authconfig(args.ldap_uri, args.base_dn)
-    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout)
-    augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
+    run_authconfig(args.ldap_uri, args.base_dn, args.debug)
+    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout, args.debug)
+    augment_sshd_config(args.debug)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
 
     if args.enable_ldap_sudoers:
-        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval, args.debug)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -81,11 +83,15 @@ def install_dependencies():
     os.system('yum install -y sssd authconfig')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key):
+def write_foxpass_ssh_keys_script(apis, api_key, debug):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
+
+    from_file = []
+    if debug and os.path.exists('/usr/local/sbin/foxpass_ssh_keys.sh'):
+        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/local/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -121,14 +127,27 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
 
+    if debug:
+        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
+        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
 
-def run_authconfig(uri, base_dn):
+
+def run_authconfig(uri, base_dn, debug):
+    from_file = []
+    if debug and os.path.exists('/etc/sssd/sssd.conf'):
+        from_file = open_file('/etc/sssd/sssd.conf')
     cmd = 'authconfig --enablesssd --enablesssdauth --enablelocauthorize --enableldap --enableldapauth --ldapserver={uri} --disableldaptls --ldapbasedn={base_dn} --enablemkhomedir --enablecachecreds --update'.format(uri=uri, base_dn=base_dn)
     print('Running %s' % cmd)
     os.system(cmd)
+    if debug:
+        to_file = open_file('/etc/sssd/sssd.conf')
+        diff_files(from_file, to_file, '/etc/sssd/sssd.conf')
 
 
-def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
+def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout, debug):
+    if debug:
+        from_file = open_file('/etc/sssd/sssd.conf')
+
     from SSSDConfig import SSSDConfig
 
     sssdconfig = SSSDConfig()
@@ -151,8 +170,15 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
+    if debug:
+        to_file = open_file('/etc/sssd/sssd.conf')
+        diff_files(from_file, to_file, '/etc/sssd/sssd.conf')
 
-def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
+
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval, debug):
+    if debug:
+        from_file = open_file('/etc/sssd/sssd.conf')
+
     from SSSDConfig import SSSDConfig
     sssdconfig = SSSDConfig()
     sssdconfig.import_config('/etc/sssd/sssd.conf')
@@ -174,32 +200,62 @@ def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_ref
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    augment_openldap(base_dn)
-    augment_nsswitch()
+    augment_openldap(base_dn, debug)
+    augment_nsswitch(debug)
+
+    if debug:
+        to_file = open_file('/etc/sssd/sssd.conf')
+        diff_files(from_file, to_file, '/etc/sssd/sssd.conf')
 
 
-def augment_sshd_config():
+def augment_sshd_config(debug):
+    if debug:
+        from_file = open_file('/etc/ssh/sshd_config')
+
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
+    if debug:
+        to_file = open_file('/etc/ssh/sshd_config')
+        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-def augment_openldap(bind_dn):
+
+def augment_openldap(bind_dn, debug):
+    if debug:
+        from_file = open_file('/etc/ssh/sshd_config')
+
     if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
         with open('/etc/openldap/ldap.conf', "a") as w:
             w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
 
+    if debug:
+        to_file = open_file('/etc/ssh/sshd_config')
+        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-def augment_nsswitch():
+
+def augment_nsswitch(debug):
+    if debug:
+        from_file = open_file('/etc/nsswitch.conf')
+
     if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
         with open('/etc/nsswitch.conf', "a") as w:
             w.write("sudoers: files sss")
 
+    if debug:
+        to_file = open_file('/etc/nsswitch.conf')
+        diff_files(from_file, to_file, '/etc/nsswitch.conf')
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
+    if debug:
+        from_sudoers_file = open_file('/etc/sudoers')
+    from_foxpass_sudo_file = ''
+    if os.path.exists('/etc/sudoers.d/95-foxpass-sudo'):
+        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -211,6 +267,12 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
+
+    if debug:
+        to_sudoers_file = open_file('/etc/sudoers')
+        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 def restart():
@@ -234,6 +296,17 @@ def is_ec2_host():
         return True
     except Exception:
         return False
+
+
+def open_file(path):
+    with open(path, 'r') as file:
+        return file.readlines()
+
+
+def diff_files(from_file, to_file, filename):
+    diff = difflib.unified_diff(from_file, to_file, fromfile='Old {}'.format(filename), tofile='New {}'.format(filename))
+    for line in diff:
+        sys.stdout.write(line)
 
 
 if __name__ == '__main__':

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -60,15 +60,49 @@ def main():
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
+    if debug:
+        foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
+        sssd_path = '/etc/sssd/sssd.conf'
+        sshd_config_path = '/etc/ssh/sshd_config'
+        ldap_path = open_file('/etc/openldap/ldap.conf')
+        nsswitch_path = open_file('/etc/nsswitch.conf')
+        sudoers_path = open_file('/etc/sudoers')
+        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
+        from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        from_file_sssd = open_file(sssd_path)
+        from_file_sshd_config = open_file(sshd_config_path)
+        from_file_ldap = open_file(ldap_path)
+        from_file_nsswitch = open_file(nsswitch_path)
+        from_sudoers_file = open_file(sudoers_path)
+        from_foxpass_sudo_file = open_file(foxpass_sudo_path)
+
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
-    run_authconfig(args.ldap_uri, args.base_dn, args.debug)
-    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout, args.debug)
-    augment_sshd_config(args.debug)
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
+    write_foxpass_ssh_keys_script(apis, args.api_key)
+    run_authconfig(args.ldap_uri, args.base_dn)
+    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout)
+    augment_sshd_config()
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     if args.enable_ldap_sudoers:
-        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval, args.debug)
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
+
+    if debug:
+        to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        to_file_sssd = open_file(sssd_path)
+        to_file_sshd_config = open_file(sshd_config_path)
+        to_file_ldap = open_file(ldap_path)
+        to_file_nsswitch = open_file(nsswitch_path)
+        to_sudoers_file = open_file(sudoers_path)
+        to_foxpass_sudo_file = open_file(foxpass_sudo_path)
+
+        diff_files(from_file_foxpass_ssh_keys, to_file_foxpass_ssh_keys, foxpass_ssh_keys_path)
+        diff_files(from_file_sssd, to_file_sssd, sssd_path)
+        diff_files(from_file_sshd_config, to_file_sshd_config, sshd_config_path)
+        diff_files(from_file_ldap, to_file_ldap, ldap_path)
+        diff_files(from_file_nsswitch, to_file_nsswitch, nsswitch_path)
+        diff_files(from_sudoers_file, to_sudoers_file, sudoers_path)
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, foxpass_sudo_path)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -83,14 +117,11 @@ def install_dependencies():
     os.system('yum install -y sssd authconfig')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key, debug):
+def write_foxpass_ssh_keys_script(apis, api_key):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
-
-    if debug:
-        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/local/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -126,28 +157,14 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
 
-    if debug:
-        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
-        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
 
-
-def run_authconfig(uri, base_dn, debug):
-    if debug:
-        from_file = open_file('/etc/sssd/sssd.conf')
-
+def run_authconfig(uri, base_dn):
     cmd = 'authconfig --enablesssd --enablesssdauth --enablelocauthorize --enableldap --enableldapauth --ldapserver={uri} --disableldaptls --ldapbasedn={base_dn} --enablemkhomedir --enablecachecreds --update'.format(uri=uri, base_dn=base_dn)
     print('Running %s' % cmd)
     os.system(cmd)
 
-    if debug:
-        to_file = open_file('/etc/sssd/sssd.conf')
-        diff_files(from_file, to_file, '/etc/sssd/sssd.conf')
 
-
-def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout, debug):
-    if debug:
-        from_file = open_file('/etc/sssd/sssd.conf')
-
+def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
     from SSSDConfig import SSSDConfig
 
     sssdconfig = SSSDConfig()
@@ -170,15 +187,8 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout, debug):
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    if debug:
-        to_file = open_file('/etc/sssd/sssd.conf')
-        diff_files(from_file, to_file, '/etc/sssd/sssd.conf')
 
-
-def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval, debug):
-    if debug:
-        from_file = open_file('/etc/sssd/sssd.conf')
-
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
     from SSSDConfig import SSSDConfig
     sssdconfig = SSSDConfig()
     sssdconfig.import_config('/etc/sssd/sssd.conf')
@@ -200,60 +210,32 @@ def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_ref
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    augment_openldap(base_dn, debug)
-    augment_nsswitch(debug)
-
-    if debug:
-        to_file = open_file('/etc/sssd/sssd.conf')
-        diff_files(from_file, to_file, '/etc/sssd/sssd.conf')
+    augment_openldap(base_dn)
+    augment_nsswitch()
 
 
-def augment_sshd_config(debug):
-    if debug:
-        from_file = open_file('/etc/ssh/sshd_config')
-
+def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
-    if debug:
-        to_file = open_file('/etc/ssh/sshd_config')
-        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-
-def augment_openldap(bind_dn, debug):
-    if debug:
-        from_file = open_file('/etc/openldap/ldap.conf')
-
+def augment_openldap(bind_dn):
     if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
         with open('/etc/openldap/ldap.conf', "a") as w:
             w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
 
-    if debug:
-        to_file = open_file('/etc/openldap/ldap.conf')
-        diff_files(from_file, to_file, '/etc/openldap/ldap.conf')
 
-
-def augment_nsswitch(debug):
-    if debug:
-        from_file = open_file('/etc/nsswitch.conf')
-
+def augment_nsswitch():
     if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
         with open('/etc/nsswitch.conf', "a") as w:
             w.write("sudoers: files sss")
 
-    if debug:
-        to_file = open_file('/etc/nsswitch.conf')
-        diff_files(from_file, to_file, '/etc/nsswitch.conf')
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
-    if debug:
-        from_sudoers_file = open_file('/etc/sudoers')
-        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -265,12 +247,6 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-
-    if debug:
-        to_sudoers_file = open_file('/etc/sudoers')
-        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
-        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 def restart():

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -45,10 +45,12 @@ def main():
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
-    parser.add_argument('--require-sudoers-pw',
-                        default=False,
-                        action='store_true',
-                        help='set sudoers default password requirement')
+    parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    # Foxpass SUDOers add-on
+    parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
+    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_time parameter')
+    parser.add_argument('--full-refresh-interval', default=21600, help='In hours, default is 6 hours')
+    parser.add_argument('--smart-refresh-interval', default=900, help='In minutes, default is 15 minutes')
 
     args = parser.parse_args()
 
@@ -61,6 +63,9 @@ def main():
     configure_sssd(bind_dn, args.bind_pw, args.ldaps)
     augment_sshd_config()
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+
+    if args.enable_ldap_sudoers:
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -145,12 +150,50 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
     sssdconfig.write()
 
 
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
+    from SSSDConfig import SSSDConfig
+    sssdconfig = SSSDConfig()
+    sssdconfig.import_config('/etc/sssd/sssd.conf')
+
+    try:
+        sssdconfig.new_service('sudo')
+        sssdconfig.activate_service('sudo')
+    except:
+        pass
+
+    domain = sssdconfig.get_domain('default')
+    domain.add_provider('ldap', 'sudo')
+    domain.set_option('ldap_sudo_search_base', 'ou=SUDOers,{}'.format(base_dn))
+    domain.set_option('ldap_sudo_full_refresh_interval', full_refresh_interval)
+    domain.set_option('ldap_sudo_smart_refresh_interval', smart_refresh_interval)
+
+    sssdconfig.activate_service('sudo')
+    sssdconfig.set('sudo', 'sudo_timed', str(sudo_timed).lower())
+    sssdconfig.save_domain(domain)
+    sssdconfig.write()
+
+    augment_openldap(base_dn)
+    augment_nsswitch()
+
+
 def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
+
+
+def augment_openldap(bind_dn):
+    if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
+        with open('/etc/openldap/ldap.conf', "a") as w:
+            w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
+
+
+def augment_nsswitch():
+    if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
+        with open('/etc/nsswitch.conf', "a") as w:
+            w.write("sudoers: files sss")
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -60,14 +60,14 @@ def main():
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         sssd_path = '/etc/sssd/sssd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
-        ldap_path = open_file('/etc/openldap/ldap.conf')
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        ldap_path = '/etc/openldap/ldap.conf'
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_sssd = open_file(sssd_path)
@@ -87,7 +87,7 @@ def main():
     if args.enable_ldap_sudoers:
         configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_sssd = open_file(sssd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -60,15 +60,49 @@ def main():
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
+    if debug:
+        foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
+        sssd_path = '/etc/sssd/conf.d/authconfig-sssd.conf'
+        sshd_config_path = '/etc/ssh/sshd_config'
+        ldap_path = open_file('/etc/openldap/ldap.conf')
+        nsswitch_path = open_file('/etc/nsswitch.conf')
+        sudoers_path = open_file('/etc/sudoers')
+        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
+        from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        from_file_sssd = open_file(sssd_path)
+        from_file_sshd_config = open_file(sshd_config_path)
+        from_file_ldap = open_file(ldap_path)
+        from_file_nsswitch = open_file(nsswitch_path)
+        from_sudoers_file = open_file(sudoers_path)
+        from_foxpass_sudo_file = open_file(foxpass_sudo_path)
+
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
-    run_authconfig(args.ldap_uri, args.base_dn, args.debug)
-    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout, args.debug)
-    augment_sshd_config(args.debug)
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
+    write_foxpass_ssh_keys_script(apis, args.api_key)
+    run_authconfig(args.ldap_uri, args.base_dn)
+    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout)
+    augment_sshd_config()
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     if args.enable_ldap_sudoers:
-        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval, args.debug)
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
+
+    if debug:
+        to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        to_file_sssd = open_file(sssd_path)
+        to_file_sshd_config = open_file(sshd_config_path)
+        to_file_ldap = open_file(ldap_path)
+        to_file_nsswitch = open_file(nsswitch_path)
+        to_sudoers_file = open_file(sudoers_path)
+        to_foxpass_sudo_file = open_file(foxpass_sudo_path)
+
+        diff_files(from_file_foxpass_ssh_keys, to_file_foxpass_ssh_keys, foxpass_ssh_keys_path)
+        diff_files(from_file_sssd, to_file_sssd, sssd_path)
+        diff_files(from_file_sshd_config, to_file_sshd_config, sshd_config_path)
+        diff_files(from_file_ldap, to_file_ldap, ldap_path)
+        diff_files(from_file_nsswitch, to_file_nsswitch, nsswitch_path)
+        diff_files(from_sudoers_file, to_sudoers_file, sudoers_path)
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, foxpass_sudo_path)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -84,14 +118,11 @@ def install_dependencies():
     os.system('yum install -y sssd authconfig')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key, debug):
+def write_foxpass_ssh_keys_script(apis, api_key):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
-    
-    if debug:
-        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/local/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -127,26 +158,14 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
     
-    if debug:
-        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
-        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
 
-
-def run_authconfig(uri, base_dn, debug):
-    if debug:
-        from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
+def run_authconfig(uri, base_dn):
     cmd = 'authconfig --enablesssd --enablesssdauth --enablelocauthorize --enableldap --enableldapauth --ldapserver={uri} --disableldaptls --ldapbasedn={base_dn} --enablemkhomedir --enablecachecreds --update'.format(uri=uri, base_dn=base_dn)
     print('Running %s' % cmd)
     os.system(cmd)
-    if debug:
-        to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
-        diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
 
 
-def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout, debug):
-    if debug:
-        from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
-
+def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
     from SSSDConfig import SSSDConfig
 
     sssdconfig = SSSDConfig()
@@ -173,15 +192,8 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout, debug):
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    if debug:
-        to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
-        diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
 
-
-def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval, debug):
-    if debug:
-        from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
-
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
     from SSSDConfig import SSSDConfig
     sssdconfig = SSSDConfig()
     sssdconfig.import_config('/etc/sssd/conf.d/authconfig-sssd.conf')
@@ -203,60 +215,32 @@ def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_ref
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    augment_openldap(base_dn, debug)
-    augment_nsswitch(debug)
-
-    if debug:
-        to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
-        diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
+    augment_openldap(base_dn)
+    augment_nsswitch()
 
 
-def augment_sshd_config(debug):
-    if debug:
-        from_file = open_file('/etc/ssh/sshd_config')
-
+def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
-    if debug:
-        to_file = open_file('/etc/ssh/sshd_config')
-        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-def augment_openldap(bind_dn, debug):
-    if debug:
-        from_file = open_file('/etc/openldap/ldap.conf')
-
+def augment_openldap(bind_dn):
     if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
         with open('/etc/openldap/ldap.conf', "a") as w:
             w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
 
-    if debug:
-        to_file = open_file('/etc/openldap/ldap.conf')
-        diff_files(from_file, to_file, '/etc/openldap/ldap.conf')
 
-
-def augment_nsswitch(debug):
-    if debug:
-        from_file = open_file('/etc/nsswitch.conf')
-
+def augment_nsswitch():
     if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
         with open('/etc/nsswitch.conf', "a") as w:
             w.write("sudoers: files sss")
 
-    if debug:
-        to_file = open_file('/etc/nsswitch.conf')
-        diff_files(from_file, to_file, '/etc/nsswitch.conf')
-
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
-    if debug:
-        from_sudoers_file = open_file('/etc/sudoers')
-        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -268,12 +252,6 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
-
-    if debug:
-        to_sudoers_file = open_file('/etc/sudoers')
-        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
-        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 def restart():

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -26,6 +26,7 @@
 
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys
@@ -47,9 +48,10 @@ def main():
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
     parser.add_argument('--opt-timeout', default=6, help='option to set the sssd opt timeout')
+    parser.add_argument('--debug', default=False, action='store_true', help='Turn on debug mode')
     # Foxpass SUDOers add-on
     parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
-    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_time parameter')
+    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_timed parameter')
     parser.add_argument('--full-refresh-interval', default=21600, help='In hours, default is 6 hours')
     parser.add_argument('--smart-refresh-interval', default=900, help='In minutes, default is 15 minutes')
 
@@ -59,14 +61,14 @@ def main():
     apis = [args.api_url] + args.apis
 
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key)
-    run_authconfig(args.ldap_uri, args.base_dn)
-    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout)
-    augment_sshd_config()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
+    run_authconfig(args.ldap_uri, args.base_dn, args.debug)
+    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout, args.debug)
+    augment_sshd_config(args.debug)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
 
     if args.enable_ldap_sudoers:
-        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval, args.debug)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -82,11 +84,14 @@ def install_dependencies():
     os.system('yum install -y sssd authconfig')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key):
+def write_foxpass_ssh_keys_script(apis, api_key, debug):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
+    
+    if debug:
+        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/local/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -121,15 +126,27 @@ exit $?
 
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
+    
+    if debug:
+        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
+        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
 
 
-def run_authconfig(uri, base_dn):
+def run_authconfig(uri, base_dn, debug):
+    if debug:
+        from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
     cmd = 'authconfig --enablesssd --enablesssdauth --enablelocauthorize --enableldap --enableldapauth --ldapserver={uri} --disableldaptls --ldapbasedn={base_dn} --enablemkhomedir --enablecachecreds --update'.format(uri=uri, base_dn=base_dn)
     print('Running %s' % cmd)
     os.system(cmd)
+    if debug:
+        to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
+        diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
 
 
 def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
+    if debug:
+        from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
+
     from SSSDConfig import SSSDConfig
 
     sssdconfig = SSSDConfig()
@@ -156,8 +173,15 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
+    if debug:
+        to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
+        diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
 
-def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
+
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval, debug):
+    if debug:
+        from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
+
     from SSSDConfig import SSSDConfig
     sssdconfig = SSSDConfig()
     sssdconfig.import_config('/etc/sssd/conf.d/authconfig-sssd.conf')
@@ -182,29 +206,57 @@ def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_ref
     augment_openldap(base_dn)
     augment_nsswitch()
 
+    if debug:
+        to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
+        diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
 
-def augment_sshd_config():
+
+def augment_sshd_config(debug):
+    if debug:
+        from_file = open_file('/etc/ssh/sshd_config')
+
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
+    if debug:
+        to_file = open_file('/etc/ssh/sshd_config')
+        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
 def augment_openldap(bind_dn):
+    if debug:
+        from_file = open_file('/etc/openldap/ldap.conf')
+
     if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
         with open('/etc/openldap/ldap.conf', "a") as w:
             w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
 
+    if debug:
+        to_file = open_file('/etc/openldap/ldap.conf')
+        diff_files(from_file, to_file, '/etc/openldap/ldap.conf')
+
 
 def augment_nsswitch():
+    if debug:
+        from_file = open_file('/etc/nsswitch.conf')
+
     if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
         with open('/etc/nsswitch.conf', "a") as w:
             w.write("sudoers: files sss")
 
+    if debug:
+        to_file = open_file('/etc/nsswitch.conf')
+        diff_files(from_file, to_file, '/etc/nsswitch.conf')
+
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
 def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+    if debug:
+        from_sudoers_file = open_file('/etc/sudoers')
+        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -216,6 +268,12 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^# %wheel\tALL=(ALL)\tNOPASSWD: ALL/%wheel\tALL=(ALL)\tNOPASSWD:ALL/' /etc/sudoers")
+
+    if debug:
+        to_sudoers_file = open_file('/etc/sudoers')
+        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 def restart():
@@ -239,6 +297,20 @@ def is_ec2_host():
         return True
     except Exception:
         return False
+
+
+def open_file(path):
+    if os.path.exists(path):
+        with open(path, 'r') as file:
+            return file.readlines()
+    else:
+        return []
+
+
+def diff_files(from_file, to_file, filename):
+    diff = difflib.unified_diff(from_file, to_file, fromfile='Old {}'.format(filename), tofile='New {}'.format(filename))
+    for line in diff:
+        sys.stdout.write(line)
 
 
 if __name__ == '__main__':

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -60,14 +60,14 @@ def main():
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         sssd_path = '/etc/sssd/conf.d/authconfig-sssd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
-        ldap_path = open_file('/etc/openldap/ldap.conf')
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        ldap_path = '/etc/openldap/ldap.conf'
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_sssd = open_file(sssd_path)
@@ -87,7 +87,7 @@ def main():
     if args.enable_ldap_sudoers:
         configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_sssd = open_file(sssd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -203,8 +203,8 @@ def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_ref
     sssdconfig.save_domain(domain)
     sssdconfig.write()
 
-    augment_openldap(base_dn)
-    augment_nsswitch()
+    augment_openldap(base_dn, debug)
+    augment_nsswitch(debug)
 
     if debug:
         to_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -143,7 +143,7 @@ def run_authconfig(uri, base_dn, debug):
         diff_files(from_file, to_file, '/etc/sssd/conf.d/authconfig-sssd.conf')
 
 
-def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
+def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout, debug):
     if debug:
         from_file = open_file('/etc/sssd/conf.d/authconfig-sssd.conf')
 
@@ -225,7 +225,7 @@ def augment_sshd_config(debug):
         to_file = open_file('/etc/ssh/sshd_config')
         diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-def augment_openldap(bind_dn):
+def augment_openldap(bind_dn, debug):
     if debug:
         from_file = open_file('/etc/openldap/ldap.conf')
 
@@ -238,7 +238,7 @@ def augment_openldap(bind_dn):
         diff_files(from_file, to_file, '/etc/openldap/ldap.conf')
 
 
-def augment_nsswitch():
+def augment_nsswitch(debug):
     if debug:
         from_file = open_file('/etc/nsswitch.conf')
 
@@ -252,7 +252,7 @@ def augment_nsswitch():
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
     if debug:
         from_sudoers_file = open_file('/etc/sudoers')
         from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -57,16 +57,16 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         nslcd_path = '/etc/nslcd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
         cs_path = '/etc/pam.d/common-session'
         csn_path = '/etc/pam.d/common-session-noninteractive'
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
+        sudo_ldap_path = '/etc/sudo-ldap.conf'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_nslcd = open_file(nslcd_path)
@@ -87,7 +87,7 @@ def main():
     fix_nsswitch()
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_nslcd = open_file(nslcd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -26,6 +26,7 @@
 
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys
@@ -47,10 +48,8 @@ def main():
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
-    parser.add_argument('--require-sudoers-pw',
-                        default=False,
-                        action='store_true',
-                        help='set sudoers default password requirement')
+    parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    parser.add_argument('--debug', default=False, action='store_true', help='Turn on debug mode')
 
     args = parser.parse_args()
 
@@ -60,12 +59,12 @@ def main():
 
     apt_get_update()
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key)
-    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit)
-    augment_sshd_config()
-    augment_pam()
-    fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
+    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit, args.debug)
+    augment_sshd_config(args.debug)
+    augment_pam(args.debug)
+    fix_nsswitch(args.debug)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
     restart()
 
 
@@ -83,11 +82,14 @@ def install_dependencies():
     os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y curl libnss-ldapd nscd nslcd')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key):
+def write_foxpass_ssh_keys_script(apis, api_key, debug):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
+
+    if debug:
+        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -123,9 +125,16 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/sbin/foxpass_ssh_keys.sh')
 
+    if debug:
+        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
+        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
+
 
 # write nslcd.conf, with substutions
-def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit):
+def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit, debug):
+    if debug:
+        from_file = open_file('/etc/nslcd.conf')
+
     with open('/etc/nslcd.conf', "w") as w:
         content = """\
 # /etc/nslcd.conf
@@ -176,16 +185,31 @@ nss_initgroups_ignoreusers ALLLOCAL
         w.write(content.format(uris='\nuri '.join(uris), basedn=basedn, binddn=binddn,
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
+    if debug:
+        to_file = open_file('/etc/nslcd.conf')
+        diff_files(from_file, to_file, '/etc/nslcd.conf')
 
-def augment_sshd_config():
+
+def augment_sshd_config(debug):
+    if debug:
+        from_file = open_file('/etc/ssh/sshd_config')
+
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
+    if debug:
+        to_file = open_file('/etc/ssh/sshd_config')
+        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
+
 
 def augment_pam():
+    if debug:
+        from_cs_file = open_file('/etc/pam.d/common-session')
+        from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
+
     if not file_contains('/etc/pam.d/common-session', r'pam_mkhomedir.so'):
         with open('/etc/pam.d/common-session', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
@@ -194,15 +218,32 @@ def augment_pam():
         with open('/etc/pam.d/common-session-noninteractive', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
 
+    if debug:
+        to_cs_file = open_file('/etc/pam.d/common-session')
+        to_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
+        diff_files(from_cs_file, to_cs_file, '/etc/pam.d/common-session')
+        diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
+
 
 def fix_nsswitch():
+    if debug:
+        from_file = open_file('/etc/nsswitch.conf')
+
     os.system("sed -i 's/passwd:.*/passwd:         compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/group:.*/group:          compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
+    if debug:
+        to_file = open_file('/etc/nsswitch.conf')
+        diff_files(from_file, to_file, '/etc/nsswitch.conf')
+
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
 def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+    if debug:
+        from_sudoers_file = open_file('/etc/sudoers')
+        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -214,6 +255,12 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
+
+    if debug:
+        to_sudoers_file = open_file('/etc/sudoers')
+        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 # check file permissions (mask should be in octal short hand ie 0644 or 0600)
@@ -252,6 +299,20 @@ def is_ec2_host():
         return True
     except Exception:
         return False
+
+
+def open_file(path):
+    if os.path.exists(path):
+        with open(path, 'r') as file:
+            return file.readlines()
+    else:
+        return []
+
+
+def diff_files(from_file, to_file, filename):
+    diff = difflib.unified_diff(from_file, to_file, fromfile='Old {}'.format(filename), tofile='New {}'.format(filename))
+    for line in diff:
+        sys.stdout.write(line)
 
 
 if __name__ == '__main__':

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -57,14 +57,57 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
+    if debug:
+        foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
+        nslcd_path = '/etc/nslcd.conf'
+        sshd_config_path = '/etc/ssh/sshd_config'
+        cs_path = '/etc/pam.d/common-session'
+        csn_path = '/etc/pam.d/common-session-noninteractive'
+        nsswitch_path = open_file('/etc/nsswitch.conf')
+        sudoers_path = open_file('/etc/sudoers')
+        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+
+        from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        from_file_nslcd = open_file(nslcd_path)
+        from_file_sshd_config = open_file(sshd_config_path)
+        from_file_cs = open_file(cs_path)
+        from_file_csn = open_file(csn_path)
+        from_file_nsswitch = open_file(nsswitch_path)
+        from_sudoers_file = open_file(sudoers_path)
+        from_foxpass_sudo_file = open_file(foxpass_sudo_path)
+        from_file_sudo_ldap = open_file(sudo_ldap_path)
+
     apt_get_update()
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
-    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit, args.debug)
-    augment_sshd_config(args.debug)
-    augment_pam(args.debug)
-    fix_nsswitch(args.debug)
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
+    write_foxpass_ssh_keys_script(apis, args.api_key)
+    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit)
+    augment_sshd_config()
+    augment_pam()
+    fix_nsswitch()
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+
+    if debug:
+        to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        to_file_nslcd = open_file(nslcd_path)
+        to_file_sshd_config = open_file(sshd_config_path)
+        to_file_cs = open_file(cs_path)
+        to_file_csn = open_file(csn_path)
+        to_file_nsswitch = open_file(nsswitch_path)
+        to_sudoers_file = open_file(sudoers_path)
+        to_foxpass_sudo_file = open_file(foxpass_sudo_path)
+        to_file_sudo_ldap = open_file(sudo_ldap_path)
+
+        diff_files(from_file_foxpass_ssh_keys, to_file_foxpass_ssh_keys, foxpass_ssh_keys_path)
+        diff_files(from_file_nslcd, to_file_nslcd, nslcd_path)
+        diff_files(from_file_sshd_config, to_file_sshd_config, sshd_config_path)
+        diff_files(from_file_cs, to_file_cs, cs_path)
+        diff_files(from_file_csn, to_file_csn, csn_path)
+        diff_files(from_file_nsswitch, to_file_nsswitch, nsswitch_path)
+        diff_files(from_sudoers_file, to_sudoers_file, sudoers_path)
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, foxpass_sudo_path)
+        diff_files(from_file_sudo_ldap, to_file_sudo_ldap, sudo_ldap_path)
+
     restart()
 
 
@@ -82,14 +125,11 @@ def install_dependencies():
     os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y curl libnss-ldapd nscd nslcd')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key, debug):
+def write_foxpass_ssh_keys_script(apis, api_key):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
-
-    if debug:
-        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -125,16 +165,9 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/sbin/foxpass_ssh_keys.sh')
 
-    if debug:
-        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
-        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
-
 
 # write nslcd.conf, with substutions
-def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit, debug):
-    if debug:
-        from_file = open_file('/etc/nslcd.conf')
-
+def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit):
     with open('/etc/nslcd.conf', "w") as w:
         content = """\
 # /etc/nslcd.conf
@@ -185,31 +218,16 @@ nss_initgroups_ignoreusers ALLLOCAL
         w.write(content.format(uris='\nuri '.join(uris), basedn=basedn, binddn=binddn,
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
-    if debug:
-        to_file = open_file('/etc/nslcd.conf')
-        diff_files(from_file, to_file, '/etc/nslcd.conf')
 
-
-def augment_sshd_config(debug):
-    if debug:
-        from_file = open_file('/etc/ssh/sshd_config')
-
+def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
-    if debug:
-        to_file = open_file('/etc/ssh/sshd_config')
-        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-
-def augment_pam(debug):
-    if debug:
-        from_cs_file = open_file('/etc/pam.d/common-session')
-        from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
-
+def augment_pam():
     if not file_contains('/etc/pam.d/common-session', r'pam_mkhomedir.so'):
         with open('/etc/pam.d/common-session', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
@@ -218,32 +236,15 @@ def augment_pam(debug):
         with open('/etc/pam.d/common-session-noninteractive', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
 
-    if debug:
-        to_cs_file = open_file('/etc/pam.d/common-session')
-        to_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
-        diff_files(from_cs_file, to_cs_file, '/etc/pam.d/common-session')
-        diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
 
-
-def fix_nsswitch(debug):
-    if debug:
-        from_file = open_file('/etc/nsswitch.conf')
-
+def fix_nsswitch():
     os.system("sed -i 's/passwd:.*/passwd:         compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/group:.*/group:          compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
-    if debug:
-        to_file = open_file('/etc/nsswitch.conf')
-        diff_files(from_file, to_file, '/etc/nsswitch.conf')
-
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
-    if debug:
-        from_sudoers_file = open_file('/etc/sudoers')
-        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -255,12 +256,6 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
-
-    if debug:
-        to_sudoers_file = open_file('/etc/sudoers')
-        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
-        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 # check file permissions (mask should be in octal short hand ie 0644 or 0600)

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -205,7 +205,7 @@ def augment_sshd_config(debug):
         diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
 
-def augment_pam():
+def augment_pam(debug):
     if debug:
         from_cs_file = open_file('/etc/pam.d/common-session')
         from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
@@ -225,7 +225,7 @@ def augment_pam():
         diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
 
 
-def fix_nsswitch():
+def fix_nsswitch(debug):
     if debug:
         from_file = open_file('/etc/nsswitch.conf')
 
@@ -239,7 +239,7 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
     if debug:
         from_sudoers_file = open_file('/etc/sudoers')
         from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -27,6 +27,7 @@
 from __future__ import print_function
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys
@@ -48,10 +49,8 @@ def main():
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
-    parser.add_argument('--require-sudoers-pw',
-                        default=False,
-                        action='store_true',
-                        help='set sudoers default password requirement')
+    parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    parser.add_argument('--debug', default=False, action='store_true', help='Turn on debug mode')
 
     args = parser.parse_args()
 
@@ -61,12 +60,12 @@ def main():
 
     apt_get_update()
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key)
-    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit)
-    augment_sshd_config()
-    augment_pam()
-    fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
+    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit, args.debug)
+    augment_sshd_config(args.debug)
+    augment_pam(args.debug)
+    fix_nsswitch(args.debug)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
     restart()
 
 
@@ -84,11 +83,14 @@ def install_dependencies():
     os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y curl libnss-ldapd nscd nslcd')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key):
+def write_foxpass_ssh_keys_script(apis, api_key, debug):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
+
+    if debug:
+        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -124,9 +126,16 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/sbin/foxpass_ssh_keys.sh')
 
+    if debug:
+        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
+        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
+
 
 # write nslcd.conf, with substutions
-def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit):
+def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit, debug):
+    if debug:
+        from_file = open_file('/etc/nslcd.conf')
+
     with open('/etc/nslcd.conf', "w") as w:
         content = """\
 # /etc/nslcd.conf
@@ -177,16 +186,31 @@ nss_initgroups_ignoreusers ALLLOCAL
         w.write(content.format(uris='\nuri '.join(uris), basedn=basedn, binddn=binddn,
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
+    if debug:
+        to_file = open_file('/etc/nslcd.conf')
+        diff_files(from_file, to_file, '/etc/nslcd.conf')
 
-def augment_sshd_config():
+
+def augment_sshd_config(debug):
+    if debug:
+        from_file = open_file('/etc/ssh/sshd_config')
+
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
+    if debug:
+        to_file = open_file('/etc/ssh/sshd_config')
+        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-def augment_pam():
+
+def augment_pam(debug):
+    if debug:
+        from_cs_file = open_file('/etc/pam.d/common-session')
+        from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
+
     if not file_contains('/etc/pam.d/common-session', r'pam_mkhomedir.so'):
         with open('/etc/pam.d/common-session', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
@@ -195,15 +219,32 @@ def augment_pam():
         with open('/etc/pam.d/common-session-noninteractive', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
 
+    if debug:
+        to_cs_file = open_file('/etc/pam.d/common-session')
+        to_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
+        diff_files(from_cs_file, to_cs_file, '/etc/pam.d/common-session')
+        diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
 
-def fix_nsswitch():
+
+def fix_nsswitch(debug):
+    if debug:
+        from_file = open_file('/etc/nsswitch.conf')
+
     os.system("sed -i 's/passwd:.*/passwd:         compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/group:.*/group:          compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
+    if debug:
+        to_file = open_file('/etc/nsswitch.conf')
+        diff_files(from_file, to_file, '/etc/nsswitch.conf')
+
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
+    if debug:
+        from_sudoers_file = open_file('/etc/sudoers')
+        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -215,6 +256,12 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
+
+    if debug:
+        to_sudoers_file = open_file('/etc/sudoers')
+        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 # check file permissions (mask should be in octal short hand ie 0644 or 0600)
@@ -253,6 +300,20 @@ def is_ec2_host():
         return True
     except Exception:
         return False
+
+
+def open_file(path):
+    if os.path.exists(path):
+        with open(path, 'r') as file:
+            return file.readlines()
+    else:
+        return []
+
+
+def diff_files(from_file, to_file, filename):
+    diff = difflib.unified_diff(from_file, to_file, fromfile='Old {}'.format(filename), tofile='New {}'.format(filename))
+    for line in diff:
+        sys.stdout.write(line)
 
 
 if __name__ == '__main__':

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -58,16 +58,16 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         nslcd_path = '/etc/nslcd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
         cs_path = '/etc/pam.d/common-session'
         csn_path = '/etc/pam.d/common-session-noninteractive'
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
+        sudo_ldap_path = '/etc/sudo-ldap.conf'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_nslcd = open_file(nslcd_path)
@@ -88,7 +88,7 @@ def main():
     fix_nsswitch()
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_nslcd = open_file(nslcd_path)
         to_file_sshd_config = open_file(sshd_config_path)
@@ -220,10 +220,7 @@ nss_initgroups_ignoreusers ALLLOCAL
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
 
-def augment_sshd_config(debug):
-    if debug:
-        from_file = open_file('/etc/ssh/sshd_config')
-
+def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
@@ -248,7 +245,7 @@ def fix_nsswitch():
 
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -58,14 +58,57 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
+    if debug:
+        foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
+        nslcd_path = '/etc/nslcd.conf'
+        sshd_config_path = '/etc/ssh/sshd_config'
+        cs_path = '/etc/pam.d/common-session'
+        csn_path = '/etc/pam.d/common-session-noninteractive'
+        nsswitch_path = open_file('/etc/nsswitch.conf')
+        sudoers_path = open_file('/etc/sudoers')
+        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+
+        from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        from_file_nslcd = open_file(nslcd_path)
+        from_file_sshd_config = open_file(sshd_config_path)
+        from_file_cs = open_file(cs_path)
+        from_file_csn = open_file(csn_path)
+        from_file_nsswitch = open_file(nsswitch_path)
+        from_sudoers_file = open_file(sudoers_path)
+        from_foxpass_sudo_file = open_file(foxpass_sudo_path)
+        from_file_sudo_ldap = open_file(sudo_ldap_path)
+
     apt_get_update()
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
-    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit, args.debug)
-    augment_sshd_config(args.debug)
-    augment_pam(args.debug)
-    fix_nsswitch(args.debug)
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
+    write_foxpass_ssh_keys_script(apis, args.api_key)
+    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit)
+    augment_sshd_config()
+    augment_pam()
+    fix_nsswitch()
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+
+    if debug:
+        to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        to_file_nslcd = open_file(nslcd_path)
+        to_file_sshd_config = open_file(sshd_config_path)
+        to_file_cs = open_file(cs_path)
+        to_file_csn = open_file(csn_path)
+        to_file_nsswitch = open_file(nsswitch_path)
+        to_sudoers_file = open_file(sudoers_path)
+        to_foxpass_sudo_file = open_file(foxpass_sudo_path)
+        to_file_sudo_ldap = open_file(sudo_ldap_path)
+
+        diff_files(from_file_foxpass_ssh_keys, to_file_foxpass_ssh_keys, foxpass_ssh_keys_path)
+        diff_files(from_file_nslcd, to_file_nslcd, nslcd_path)
+        diff_files(from_file_sshd_config, to_file_sshd_config, sshd_config_path)
+        diff_files(from_file_cs, to_file_cs, cs_path)
+        diff_files(from_file_csn, to_file_csn, csn_path)
+        diff_files(from_file_nsswitch, to_file_nsswitch, nsswitch_path)
+        diff_files(from_sudoers_file, to_sudoers_file, sudoers_path)
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, foxpass_sudo_path)
+        diff_files(from_file_sudo_ldap, to_file_sudo_ldap, sudo_ldap_path)
+
     restart()
 
 
@@ -83,14 +126,11 @@ def install_dependencies():
     os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y curl libnss-ldapd nscd nslcd')
 
 
-def write_foxpass_ssh_keys_script(apis, api_key, debug):
+def write_foxpass_ssh_keys_script(apis, api_key):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
-
-    if debug:
-        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -126,16 +166,9 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/sbin/foxpass_ssh_keys.sh')
 
-    if debug:
-        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
-        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
-
 
 # write nslcd.conf, with substutions
-def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit, debug):
-    if debug:
-        from_file = open_file('/etc/nslcd.conf')
-
+def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit):
     with open('/etc/nslcd.conf', "w") as w:
         content = """\
 # /etc/nslcd.conf
@@ -186,10 +219,6 @@ nss_initgroups_ignoreusers ALLLOCAL
         w.write(content.format(uris='\nuri '.join(uris), basedn=basedn, binddn=binddn,
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
-    if debug:
-        to_file = open_file('/etc/nslcd.conf')
-        diff_files(from_file, to_file, '/etc/nslcd.conf')
-
 
 def augment_sshd_config(debug):
     if debug:
@@ -201,16 +230,8 @@ def augment_sshd_config(debug):
             w.write("AuthorizedKeysCommand\t\t/usr/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
-    if debug:
-        to_file = open_file('/etc/ssh/sshd_config')
-        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-
-def augment_pam(debug):
-    if debug:
-        from_cs_file = open_file('/etc/pam.d/common-session')
-        from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
-
+def augment_pam():
     if not file_contains('/etc/pam.d/common-session', r'pam_mkhomedir.so'):
         with open('/etc/pam.d/common-session', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
@@ -219,32 +240,15 @@ def augment_pam(debug):
         with open('/etc/pam.d/common-session-noninteractive', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
 
-    if debug:
-        to_cs_file = open_file('/etc/pam.d/common-session')
-        to_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
-        diff_files(from_cs_file, to_cs_file, '/etc/pam.d/common-session')
-        diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
 
-
-def fix_nsswitch(debug):
-    if debug:
-        from_file = open_file('/etc/nsswitch.conf')
-
+def fix_nsswitch():
     os.system("sed -i 's/passwd:.*/passwd:         compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/group:.*/group:          compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
-    if debug:
-        to_file = open_file('/etc/nsswitch.conf')
-        diff_files(from_file, to_file, '/etc/nsswitch.conf')
-
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
 def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
-    if debug:
-        from_sudoers_file = open_file('/etc/sudoers')
-        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -256,12 +260,6 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
-
-    if debug:
-        to_sudoers_file = open_file('/etc/sudoers')
-        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
-        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 # check file permissions (mask should be in octal short hand ie 0644 or 0600)

--- a/linux/redhat/foxpass_setup.py
+++ b/linux/redhat/foxpass_setup.py
@@ -60,14 +60,14 @@ def main():
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         sssd_path = '/etc/sssd/conf.d/authconfig-sssd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
-        ldap_path = open_file('/etc/openldap/ldap.conf')
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        ldap_path = '/etc/openldap/ldap.conf'
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_sssd = open_file(sssd_path)
@@ -87,7 +87,7 @@ def main():
     if args.enable_ldap_sudoers:
         configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_sssd = open_file(sssd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/redhat/foxpass_setup.py
+++ b/linux/redhat/foxpass_setup.py
@@ -26,6 +26,7 @@
 
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys
@@ -45,23 +46,63 @@ def main():
     parser.add_argument('--secondary-api', dest='apis', default=[], action='append', help='Secondary API Server(s)')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
-    parser.add_argument('--require-sudoers-pw',
-                        default=False,
-                        action='store_true',
-                        help='set sudoers default password requirement')
+    parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    parser.add_argument('--opt-timeout', default=6, help='option to set the sssd opt timeout')
+    parser.add_argument('--debug', default=False, action='store_true', help='Turn on debug mode')
+    # Foxpass SUDOers add-on
+    parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
+    parser.add_argument('--sudo-timed', default=False, action='store_true', help='Toggle sudo_timed parameter')
+    parser.add_argument('--full-refresh-interval', default=21600, help='In hours, default is 6 hours')
+    parser.add_argument('--smart-refresh-interval', default=900, help='In minutes, default is 15 minutes')
 
     args = parser.parse_args()
 
     bind_dn = 'cn=%s,%s' % (args.bind_user, args.base_dn)
     apis = [args.api_url] + args.apis
 
+    if debug:
+        foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
+        sssd_path = '/etc/sssd/conf.d/authconfig-sssd.conf'
+        sshd_config_path = '/etc/ssh/sshd_config'
+        ldap_path = open_file('/etc/openldap/ldap.conf')
+        nsswitch_path = open_file('/etc/nsswitch.conf')
+        sudoers_path = open_file('/etc/sudoers')
+        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
+        from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        from_file_sssd = open_file(sssd_path)
+        from_file_sshd_config = open_file(sshd_config_path)
+        from_file_ldap = open_file(ldap_path)
+        from_file_nsswitch = open_file(nsswitch_path)
+        from_sudoers_file = open_file(sudoers_path)
+        from_foxpass_sudo_file = open_file(foxpass_sudo_path)
+
     install_dependencies()
     write_foxpass_ssh_keys_script(apis, args.api_key)
     run_authconfig(args.ldap_uri, args.base_dn)
-    run_authselect()
-    configure_sssd(bind_dn, args.bind_pw, args.ldaps)
+    configure_sssd(bind_dn, args.bind_pw, args.ldaps, args.opt_timeout)
     augment_sshd_config()
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
+
+    if args.enable_ldap_sudoers:
+        configure_ldap_sudoers(args.base_dn, args.sudo_timed, args.full_refresh_interval, args.smart_refresh_interval)
+
+    if debug:
+        to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        to_file_sssd = open_file(sssd_path)
+        to_file_sshd_config = open_file(sshd_config_path)
+        to_file_ldap = open_file(ldap_path)
+        to_file_nsswitch = open_file(nsswitch_path)
+        to_sudoers_file = open_file(sudoers_path)
+        to_foxpass_sudo_file = open_file(foxpass_sudo_path)
+
+        diff_files(from_file_foxpass_ssh_keys, to_file_foxpass_ssh_keys, foxpass_ssh_keys_path)
+        diff_files(from_file_sssd, to_file_sssd, sssd_path)
+        diff_files(from_file_sshd_config, to_file_sshd_config, sshd_config_path)
+        diff_files(from_file_ldap, to_file_ldap, ldap_path)
+        diff_files(from_file_nsswitch, to_file_nsswitch, nsswitch_path)
+        diff_files(from_sudoers_file, to_sudoers_file, sudoers_path)
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, foxpass_sudo_path)
 
     # sleep to the next second to make sure sssd.conf has a new timestamp
     time.sleep(1)
@@ -116,7 +157,7 @@ exit $?
 
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
-
+    
 
 def run_authconfig(uri, base_dn):
     cmd = 'authconfig --enablesssd --enablesssdauth --enablelocauthorize --enableldap --enableldapauth --ldapserver={uri} --disableldaptls --ldapbasedn={base_dn} --enablemkhomedir --enablecachecreds --update'.format(uri=uri, base_dn=base_dn)
@@ -124,18 +165,16 @@ def run_authconfig(uri, base_dn):
     os.system(cmd)
 
 
-def run_authselect():
-    cmd = 'authselect select sssd with-mkhomedir '
-    print('Running %s' % cmd)
-    os.system(cmd)
-
-
-def configure_sssd(bind_dn, bind_pw, backup_ldaps):
+def configure_sssd(bind_dn, bind_pw, backup_ldaps, opt_timeout):
     from SSSDConfig import SSSDConfig
 
     sssdconfig = SSSDConfig()
     sssdconfig.import_config('/etc/sssd/conf.d/authconfig-sssd.conf')
 
+    sssdconfig.new_service('pam')
+    sssdconfig.new_service('nss')
+    sssdconfig.activate_service('pam')
+    sssdconfig.activate_service('nss')
     domain = sssdconfig.get_domain('default')
     domain.add_provider('ldap', 'id')
     if backup_ldaps:
@@ -144,6 +183,7 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
     domain.set_option('ldap_tls_cacert', '/etc/ssl/certs/ca-bundle.crt')
     domain.set_option('ldap_default_bind_dn', bind_dn)
     domain.set_option('ldap_default_authtok', bind_pw)
+    domain.set_option('ldap_opt_timeout', opt_timeout)
     domain.set_option('enumerate', True)
     domain.remove_option('ldap_tls_cacertdir')
 
@@ -153,12 +193,50 @@ def configure_sssd(bind_dn, bind_pw, backup_ldaps):
     sssdconfig.write()
 
 
+def configure_ldap_sudoers(base_dn, sudo_timed, full_refresh_interval, smart_refresh_interval):
+    from SSSDConfig import SSSDConfig
+    sssdconfig = SSSDConfig()
+    sssdconfig.import_config('/etc/sssd/conf.d/authconfig-sssd.conf')
+
+    try:
+        sssdconfig.new_service('sudo')
+        sssdconfig.activate_service('sudo')
+    except:
+        pass
+
+    domain = sssdconfig.get_domain('default')
+    domain.add_provider('ldap', 'sudo')
+    domain.set_option('ldap_sudo_search_base', 'ou=SUDOers,{}'.format(base_dn))
+    domain.set_option('ldap_sudo_full_refresh_interval', full_refresh_interval)
+    domain.set_option('ldap_sudo_smart_refresh_interval', smart_refresh_interval)
+
+    sssdconfig.activate_service('sudo')
+    sssdconfig.set('sudo', 'sudo_timed', str(sudo_timed).lower())
+    sssdconfig.save_domain(domain)
+    sssdconfig.write()
+
+    augment_openldap(base_dn)
+    augment_nsswitch()
+
+
 def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
+
+
+def augment_openldap(bind_dn):
+    if not file_contains('/etc/openldap/ldap.conf', r'^SUDOERS_BASE'):
+        with open('/etc/openldap/ldap.conf', "a") as w:
+            w.write("\nSUDOERS_BASE ou=SUDOers,{}".format(bind_dn))
+
+
+def augment_nsswitch():
+    if not file_contains('/etc/nsswitch.conf', r'^sudoers:'):
+        with open('/etc/nsswitch.conf', "a") as w:
+            w.write("sudoers: files sss")
 
 
 # give "wheel" and chosen sudoers groups sudo permissions without password
@@ -197,6 +275,20 @@ def is_ec2_host():
         return True
     except Exception:
         return False
+
+
+def open_file(path):
+    if os.path.exists(path):
+        with open(path, 'r') as file:
+            return file.readlines()
+    else:
+        return []
+
+
+def diff_files(from_file, to_file, filename):
+    diff = difflib.unified_diff(from_file, to_file, fromfile='Old {}'.format(filename), tofile='New {}'.format(filename))
+    for line in diff:
+        sys.stdout.write(line)
 
 
 if __name__ == '__main__':

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -61,16 +61,16 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         nslcd_path = '/etc/nslcd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
         cs_path = '/etc/pam.d/common-session'
         csn_path = '/etc/pam.d/common-session-noninteractive'
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
+        sudo_ldap_path = '/etc/sudo-ldap.conf'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_nslcd = open_file(nslcd_path)
@@ -94,7 +94,7 @@ def main():
     if args.enable_ldap_sudoers:
         write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_nslcd = open_file(nslcd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -61,17 +61,59 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
+    if debug:
+        foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
+        nslcd_path = '/etc/nslcd.conf'
+        sshd_config_path = '/etc/ssh/sshd_config'
+        cs_path = '/etc/pam.d/common-session'
+        csn_path = '/etc/pam.d/common-session-noninteractive'
+        nsswitch_path = open_file('/etc/nsswitch.conf')
+        sudoers_path = open_file('/etc/sudoers')
+        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+
+        from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        from_file_nslcd = open_file(nslcd_path)
+        from_file_sshd_config = open_file(sshd_config_path)
+        from_file_cs = open_file(cs_path)
+        from_file_csn = open_file(csn_path)
+        from_file_nsswitch = open_file(nsswitch_path)
+        from_sudoers_file = open_file(sudoers_path)
+        from_foxpass_sudo_file = open_file(foxpass_sudo_path)
+        from_file_sudo_ldap = open_file(sudo_ldap_path)
+
     apt_get_update()
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
-    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit, args.debug)
-    augment_sshd_config(args.debug)
-    augment_pam(args.debug)
-    fix_nsswitch(args.debug)
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
+    write_foxpass_ssh_keys_script(apis, args.api_key)
+    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit)
+    augment_sshd_config()
+    augment_pam()
+    fix_nsswitch()
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
 
     if args.enable_ldap_sudoers:
-        write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit, args.debug)
+        write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit)
+
+    if debug:
+        to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
+        to_file_nslcd = open_file(nslcd_path)
+        to_file_sshd_config = open_file(sshd_config_path)
+        to_file_cs = open_file(cs_path)
+        to_file_csn = open_file(csn_path)
+        to_file_nsswitch = open_file(nsswitch_path)
+        to_sudoers_file = open_file(sudoers_path)
+        to_foxpass_sudo_file = open_file(foxpass_sudo_path)
+        to_file_sudo_ldap = open_file(sudo_ldap_path)
+
+        diff_files(from_file_foxpass_ssh_keys, to_file_foxpass_ssh_keys, foxpass_ssh_keys_path)
+        diff_files(from_file_nslcd, to_file_nslcd, nslcd_path)
+        diff_files(from_file_sshd_config, to_file_sshd_config, sshd_config_path)
+        diff_files(from_file_cs, to_file_cs, cs_path)
+        diff_files(from_file_csn, to_file_csn, csn_path)
+        diff_files(from_file_nsswitch, to_file_nsswitch, nsswitch_path)
+        diff_files(from_sudoers_file, to_sudoers_file, sudoers_path)
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, foxpass_sudo_path)
+        diff_files(from_file_sudo_ldap, to_file_sudo_ldap, sudo_ldap_path)
 
     restart()
 
@@ -102,14 +144,11 @@ def install_dependencies():
         sys.exit(return_code >> 8)
 
 
-def write_foxpass_ssh_keys_script(apis, api_key, debug):
+def write_foxpass_ssh_keys_script(apis, api_key):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
-
-    if debug:
-        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/local/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -145,16 +184,9 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
 
-    if debug:
-        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
-        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
-
 
 # write nslcd.conf, with substutions
-def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit, debug):
-    if debug:
-        from_file = open_file('/etc/nslcd.conf')
-
+def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit):
     with open('/etc/nslcd.conf', "w") as w:
         content = """\
 # /etc/nslcd.conf
@@ -205,31 +237,16 @@ nss_initgroups_ignoreusers ALLLOCAL
         w.write(content.format(uris='\nuri '.join(uris), basedn=basedn, binddn=binddn,
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
-    if debug:
-        to_file = open_file('/etc/nslcd.conf')
-        diff_files(from_file, to_file, '/etc/nslcd.conf')
 
-
-def augment_sshd_config(debug):
-    if debug:
-        from_file = open_file('/etc/ssh/sshd_config')
-
+def augment_sshd_config():
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
-    if debug:
-        to_file = open_file('/etc/ssh/sshd_config')
-        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-
-def augment_pam(debug):
-    if debug:
-        from_cs_file = open_file('/etc/pam.d/common-session')
-        from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
-
+def augment_pam():
     if not file_contains('/etc/pam.d/common-session', r'pam_mkhomedir\.so'):
         with open('/etc/pam.d/common-session', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
@@ -238,30 +255,14 @@ def augment_pam(debug):
         with open('/etc/pam.d/common-session-noninteractive', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
 
-    if debug:
-        to_cs_file = open_file('/etc/pam.d/common-session')
-        to_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
-        diff_files(from_cs_file, to_cs_file, '/etc/pam.d/common-session')
-        diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
 
-
-def fix_nsswitch(debug):
-    if debug:
-        from_file = open_file('/etc/nsswitch.conf')
-
+def fix_nsswitch():
     os.system("sed -i 's/passwd:.*/passwd:         compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/group:.*/group:          compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
-    if debug:
-        to_file = open_file('/etc/nsswitch.conf')
-        diff_files(from_file, to_file, '/etc/nsswitch.conf')
 
-
-def write_ldap_sudoers(uris, basedn, binddn, bindpw, sudoers_timed, bind_timelimit, query_timelimit, debug):
-    if debug:
-        from_file = open_file('/etc/sudo-ldap.conf')
-
+def write_ldap_sudoers(uris, basedn, binddn, bindpw, sudoers_timed, bind_timelimit, query_timelimit):
     check_sudo_passwd()
     return_code = os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y sudo-ldap')
     if return_code != 0:
@@ -306,17 +307,9 @@ TLS_CACERT      /etc/ssl/certs/ca-certificates.crt
         w.write(content.format(uri=uris[0], basedn=basedn, binddn=binddn, bindpw=bindpw,
             sudoers_timed=str(sudoers_timed).lower(), bind_timelimit=bind_timelimit, query_timelimit=query_timelimit))
 
-    if debug:
-        to_file = open_file('/etc/sudo-ldap.conf')
-        diff_files(from_file, to_file, '/etc/sudo-ldap.conf')
-
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
-    if debug:
-        from_sudoers_file = open_file('/etc/sudoers')
-        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -329,11 +322,6 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
 
-    if debug:
-        to_sudoers_file = open_file('/etc/sudoers')
-        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
-        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 def check_sudo_passwd():
     result = os.popen('passwd --status root').read().split(' ')

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -69,7 +69,7 @@ def main():
     augment_pam(args.debug)
     fix_nsswitch(args.debug)
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
-    fix_eic(args.debug)
+    fix_eic()
 
     if args.enable_ldap_sudoers:
         write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit, args.debug)

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -26,6 +26,7 @@
 
 import argparse
 from datetime import datetime
+import difflib
 import os
 import re
 import sys
@@ -47,6 +48,7 @@ def main():
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
     parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    parser.add_argument('--debug', default=False, action='store_true', help='Turn on debug mode')
     # Foxpass SUDOers add-on
     parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
     parser.add_argument('--sudoers-timed', default=False, action='store_true', help='Toggle sudoers_timed parameter')
@@ -61,16 +63,16 @@ def main():
 
     apt_get_update()
     install_dependencies()
-    write_foxpass_ssh_keys_script(apis, args.api_key)
-    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit)
-    augment_sshd_config()
-    augment_pam()
-    fix_nsswitch()
-    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
-    fix_eic()
+    write_foxpass_ssh_keys_script(apis, args.api_key, args.debug)
+    write_nslcd_conf(uris, args.base_dn, binddn, args.bind_pw, args.ldap_connections, args.idle_timelimit, args.debug)
+    augment_sshd_config(args.debug)
+    augment_pam(args.debug)
+    fix_nsswitch(args.debug)
+    fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers, args.debug)
+    fix_eic(args.debug)
 
     if args.enable_ldap_sudoers:
-        write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit)
+        write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit, args.debug)
 
     restart()
 
@@ -101,11 +103,14 @@ def install_dependencies():
         sys.exit(return_code >> 8)
 
 
-def write_foxpass_ssh_keys_script(apis, api_key):
+def write_foxpass_ssh_keys_script(apis, api_key, debug):
     base_curl = 'curl -s -q -m 5 -f -H "Authorization: Token ${secret}" "%s/sshkeys/?user=${user}&hostname=${hostname}'
     curls = []
     for api in apis:
         curls.append(base_curl % api)
+
+    if debug:
+        from_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
 
     with open('/usr/local/sbin/foxpass_ssh_keys.sh', "w") as w:
         if is_ec2_host():
@@ -141,9 +146,16 @@ exit $?
         # give permissions only to root to protect the API key inside
         os.system('chmod 700 /usr/local/sbin/foxpass_ssh_keys.sh')
 
+    if debug:
+        to_file = open_file('/usr/local/sbin/foxpass_ssh_keys.sh')
+        diff_files(from_file, to_file, '/usr/local/sbin/foxpass_ssh_keys.sh')
+
 
 # write nslcd.conf, with substutions
-def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit):
+def write_nslcd_conf(uris, basedn, binddn, bindpw, threads, idle_timelimit, debug):
+    if debug:
+        from_file = open_file('/etc/nslcd.conf')
+
     with open('/etc/nslcd.conf', "w") as w:
         content = """\
 # /etc/nslcd.conf
@@ -194,16 +206,31 @@ nss_initgroups_ignoreusers ALLLOCAL
         w.write(content.format(uris='\nuri '.join(uris), basedn=basedn, binddn=binddn,
                                bindpw=bindpw, sslstatus=sslstatus, threads=threads, idle_timelimit=idle_timelimit))
 
+    if debug:
+        to_file = open_file('/etc/nslcd.conf')
+        diff_files(from_file, to_file, '/etc/nslcd.conf')
 
-def augment_sshd_config():
+
+def augment_sshd_config(debug):
+    if debug:
+        from_file = open_file('/etc/ssh/sshd_config')
+
     if not file_contains('/etc/ssh/sshd_config', r'^AuthorizedKeysCommand\w'):
         with open('/etc/ssh/sshd_config', "a") as w:
             w.write("\n")
             w.write("AuthorizedKeysCommand\t\t/usr/local/sbin/foxpass_ssh_keys.sh\n")
             w.write("AuthorizedKeysCommandUser\troot\n")
 
+    if debug:
+        to_file = open_file('/etc/ssh/sshd_config')
+        diff_files(from_file, to_file, '/etc/ssh/sshd_config')
 
-def augment_pam():
+
+def augment_pam(debug):
+    if debug:
+        from_cs_file = open_file('/etc/pam.d/common-session')
+        from_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
+
     if not file_contains('/etc/pam.d/common-session', r'pam_mkhomedir\.so'):
         with open('/etc/pam.d/common-session', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
@@ -212,14 +239,30 @@ def augment_pam():
         with open('/etc/pam.d/common-session-noninteractive', "a") as w:
             w.write('session required                        pam_mkhomedir.so umask=0022 skel=/etc/skel\n')
 
+    if debug:
+        to_cs_file = open_file('/etc/pam.d/common-session')
+        to_csn_file = open_file('/etc/pam.d/common-session-noninteractive')
+        diff_files(from_cs_file, to_cs_file, '/etc/pam.d/common-session')
+        diff_files(from_csn_file, to_csn_file, '/etc/pam.d/common-session-noninteractive')
 
-def fix_nsswitch():
+
+def fix_nsswitch(debug):
+    if debug:
+        from_file = open_file('/etc/nsswitch.conf')
+
     os.system("sed -i 's/passwd:.*/passwd:         compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/group:.*/group:          compat ldap/' /etc/nsswitch.conf")
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
+    if debug:
+        to_file = open_file('/etc/nsswitch.conf')
+        diff_files(from_file, to_file, '/etc/nsswitch.conf')
 
-def write_ldap_sudoers(uris, basedn, binddn, bindpw, sudoers_timed, bind_timelimit, query_timelimit):
+
+def write_ldap_sudoers(uris, basedn, binddn, bindpw, sudoers_timed, bind_timelimit, query_timelimit, debug):
+    if debug:
+        from_file = open_file('/etc/sudo-ldap.conf')
+
     check_sudo_passwd()
     return_code = os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y sudo-ldap')
     if return_code != 0:
@@ -264,9 +307,17 @@ TLS_CACERT      /etc/ssl/certs/ca-certificates.crt
         w.write(content.format(uri=uris[0], basedn=basedn, binddn=binddn, bindpw=bindpw,
             sudoers_timed=str(sudoers_timed).lower(), bind_timelimit=bind_timelimit, query_timelimit=query_timelimit))
 
+    if debug:
+        to_file = open_file('/etc/sudo-ldap.conf')
+        diff_files(from_file, to_file, '/etc/sudo-ldap.conf')
+
 
 # give "sudo" and chosen sudoers groups sudo permissions without password
-def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
+def fix_sudo(sudoers, require_sudoers_pw, update_sudoers, debug):
+    if debug:
+        from_sudoers_file = open_file('/etc/sudoers')
+        from_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
         with open('/etc/sudoers', 'a') as w:
             w.write('\n#includedir /etc/sudoers.d\n')
@@ -278,6 +329,12 @@ def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
                     format(sudo=sudoers, command='ALL' if require_sudoers_pw else 'NOPASSWD:ALL'))
     if not require_sudoers_pw:
         os.system("sed -i 's/^%sudo\tALL=(ALL:ALL) ALL/%sudo ALL=(ALL:ALL) NOPASSWD:ALL/' /etc/sudoers")
+
+    if debug:
+        to_sudoers_file = open_file('/etc/sudoers')
+        to_foxpass_sudo_file = open_file('/etc/sudoers.d/95-foxpass-sudo')
+        diff_files(from_sudoers_file, to_sudoers_file, '/etc/sudoers')
+        diff_files(from_foxpass_sudo_file, to_foxpass_sudo_file, '/etc/sudoers.d/95-foxpass-sudo')
 
 
 # Amazon is hard loading their configs if they don't dectect everything,
@@ -320,6 +377,20 @@ def is_ec2_host():
         return True
     except Exception:
         return False
+
+
+def open_file(path):
+    if os.path.exists(path):
+        with open(path, 'r') as file:
+            return file.readlines()
+    else:
+        return []
+
+
+def diff_files(from_file, to_file, filename):
+    diff = difflib.unified_diff(from_file, to_file, fromfile='Old {}'.format(filename), tofile='New {}'.format(filename))
+    for line in diff:
+        sys.stdout.write(line)
 
 
 if __name__ == '__main__':

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -61,16 +61,16 @@ def main():
     apis = [args.api_url] + args.apis
     uris = [args.ldap_uri] + args.ldaps
 
-    if debug:
+    if args.debug:
         foxpass_ssh_keys_path = '/usr/local/sbin/foxpass_ssh_keys.sh'
         nslcd_path = '/etc/nslcd.conf'
         sshd_config_path = '/etc/ssh/sshd_config'
         cs_path = '/etc/pam.d/common-session'
         csn_path = '/etc/pam.d/common-session-noninteractive'
-        nsswitch_path = open_file('/etc/nsswitch.conf')
-        sudoers_path = open_file('/etc/sudoers')
-        foxpass_sudo_path = open_file('/etc/sudoers.d/95-foxpass-sudo')
-        sudo_ldap_path = open_file('/etc/sudo-ldap.conf')
+        nsswitch_path = '/etc/nsswitch.conf'
+        sudoers_path = '/etc/sudoers'
+        foxpass_sudo_path = '/etc/sudoers.d/95-foxpass-sudo'
+        sudo_ldap_path = '/etc/sudo-ldap.conf'
 
         from_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         from_file_nslcd = open_file(nslcd_path)
@@ -95,7 +95,7 @@ def main():
     if args.enable_ldap_sudoers:
         write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit)
 
-    if debug:
+    if args.debug:
         to_file_foxpass_ssh_keys = open_file(foxpass_ssh_keys_path)
         to_file_nslcd = open_file(nslcd_path)
         to_file_sshd_config = open_file(sshd_config_path)

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -46,10 +46,12 @@ def main():
     parser.add_argument('--idle-timelimit', default=600, type=int, help='LDAP idle time out setting, default to 10m')
     parser.add_argument('--sudoers-group', default='foxpass-sudo', type=str, help='sudoers group with root access')
     parser.add_argument('--update-sudoers', default=False, action='store_true', help='update 95-foxpass-sudo with new group')
-    parser.add_argument('--require-sudoers-pw',
-                        default=False,
-                        action='store_true',
-                        help='set sudoers default password requirement')
+    parser.add_argument('--require-sudoers-pw', default=False, action='store_true', help='set sudoers default password requirement')
+    # Foxpass SUDOers add-on
+    parser.add_argument('--enable-ldap-sudoers', default=False, action='store_true', help='Enable Foxpass SUDOers')
+    parser.add_argument('--sudoers-timed', default=False, action='store_true', help='Toggle sudoers_timed parameter')
+    parser.add_argument('--bind-timelimit', default=30, help='The amount of time, in seconds, to wait while trying to connect to an LDAP server.')
+    parser.add_argument('--query-timelimit', default=30, help='The amount of time, in seconds, to wait while performing an LDAP query.')
 
     args = parser.parse_args()
 
@@ -66,6 +68,10 @@ def main():
     fix_nsswitch()
     fix_sudo(args.sudoers_group, args.require_sudoers_pw, args.update_sudoers)
     fix_eic()
+
+    if args.enable_ldap_sudoers:
+        write_ldap_sudoers(uris, args.base_dn, binddn, args.bind_pw, args.sudoers_timed, args.bind_timelimit, args.query_timelimit)
+
     restart()
 
 
@@ -213,6 +219,52 @@ def fix_nsswitch():
     os.system("sed -i 's/shadow:.*/shadow:         compat ldap/' /etc/nsswitch.conf")
 
 
+def write_ldap_sudoers(uris, basedn, binddn, bindpw, sudoers_timed, bind_timelimit, query_timelimit):
+    check_sudo_passwd()
+    return_code = os.system('DEBIAN_FRONTEND=noninteractive apt-get install -y sudo-ldap')
+    if return_code != 0:
+        # bitshift right 8 to get rid of the signal portion of the return code
+        sys.exit(return_code >> 8)
+    with open('/etc/sudo-ldap.conf', "w") as w:
+        content = """\
+#
+# LDAP Defaults
+#
+
+# See ldap.conf(5) for details
+# This file should be world readable but not world writable.
+
+URI         {uri}
+BINDDN      {binddn}
+BINDPW      {bindpw}
+
+# The amount of time, in seconds, to wait while trying to connect to
+# an LDAP server.
+bind_timelimit {bind_timelimit}
+#
+# The amount of time, in seconds, to wait while performing an LDAP query.
+timelimit {query_timelimit}
+#
+# Must be set or sudo will ignore LDAP; may be specified multiple times.
+sudoers_base   ou=SUDOers,{basedn}
+#
+# verbose sudoers matching from ldap
+sudoers_debug 0
+#
+# Enable support for time-based entries in sudoers.
+sudoers_timed {sudoers_timed}
+
+#SIZELIMIT      12
+#TIMELIMIT      15
+#DEREF          never
+
+# TLS certificates (needed for GnuTLS)
+TLS_CACERT      /etc/ssl/certs/ca-certificates.crt
+"""
+        w.write(content.format(uri=uris[0], basedn=basedn, binddn=binddn, bindpw=bindpw,
+            sudoers_timed=str(sudoers_timed).lower(), bind_timelimit=bind_timelimit, query_timelimit=query_timelimit))
+
+
 # give "sudo" and chosen sudoers groups sudo permissions without password
 def fix_sudo(sudoers, require_sudoers_pw, update_sudoers):
     if not file_contains('/etc/sudoers', r'^#includedir /etc/sudoers.d'):
@@ -237,6 +289,12 @@ def fix_eic():
         os.system('systemctl stop ssh.service')
         os.system('mv {} {}.disabled'.format(eic_file, eic_file))
         os.system('systemctl daemon-reload')
+
+
+def check_sudo_passwd():
+    result = os.popen('passwd --status root').read().split(' ')
+    if result and result[1] != 'P':
+        sys.exit('Please set the password of the `root` user before enabling ldap sudoers. E.g sudo passwd root')
 
 
 def restart():


### PR DESCRIPTION
## Description of the change

> Description here

## Type of change
- [ ] Bug fix
- [x] New feature

### Testing

- [x] Testing information has been added - test cases checklist and steps followed for testing.
- [ ] Testing screenshot(s) attached for more information.

Tested in the following distros

- CentOS 7
- CentOS 8
- Ubuntu 20.04
- Ubuntu 18.04
- Amazon Linux 2

Debug option output, it will be displayed right before the service restart

```
--- Old /etc/sssd/sssd.conf
+++ New /etc/sssd/sssd.conf
@@ -8,7 +8,12 @@
 chpass_provider = ldap
 ldap_uri = ldaps://ldap.foxpass.com
 ldap_id_use_start_tls = False
-ldap_tls_cacertdir = /etc/openldap/cacerts
+ldap_tls_reqcert = demand
+ldap_default_bind_dn = cn=xxx,dc=xxx,dc=xxx
+ldap_tls_cacert = /etc/ssl/certs/ca-bundle.crt
+ldap_opt_timeout = 6
+enumerate = True
+ldap_default_authtok = xxx
 [sssd]
 services = nss, pam, autofs

--- Old /etc/ssh/sshd_config
+++ New /etc/ssh/sshd_config
@@ -137,3 +137,6 @@
 #      AllowTcpForwarding no
 #      PermitTTY no
 #      ForceCommand cvs server
+
+AuthorizedKeysCommand          /usr/local/sbin/foxpass_ssh_keys.sh
+AuthorizedKeysCommandUser      root
--- Old /etc/sudoers
+++ New /etc/sudoers
@@ -107,7 +107,7 @@
 %wheel ALL=(ALL)       ALL

 ## Same thing without a password
-# %wheel       ALL=(ALL)       NOPASSWD: ALL
+%wheel ALL=(ALL)       NOPASSWD:ALL

 ## Allows members of the users group to mount and unmount the
 ## cdrom as root
--- Old /etc/sudoers.d/95-foxpass-sudo
+++ New /etc/sudoers.d/95-foxpass-sudo
@@ -0,0 +1,2 @@
+# Adding Foxpass group to sudoers
```