### PR TITLE
Add support for AWS IMDS version 2

### DIFF
--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -95,7 +95,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -94,8 +94,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -211,6 +220,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -94,8 +94,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -185,6 +194,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -95,7 +95,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -94,7 +94,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -93,8 +93,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -184,6 +193,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -94,7 +94,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -93,8 +93,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -184,6 +193,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/centos/6.5/foxpass_setup.py
+++ b/linux/centos/6.5/foxpass_setup.py
@@ -86,8 +86,17 @@ user="$1"
 secret="%s"
 hostname=`uname -n`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -178,6 +187,16 @@ def file_contains(filename, regex):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/centos/6.5/foxpass_setup.py
+++ b/linux/centos/6.5/foxpass_setup.py
@@ -87,7 +87,7 @@ secret="%s"
 hostname=`uname -n`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -94,7 +94,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -93,8 +93,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -184,6 +193,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -95,7 +95,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -94,8 +94,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -189,6 +198,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -101,7 +101,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -100,8 +100,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -245,6 +254,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -100,8 +100,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -232,6 +241,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -101,7 +101,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -101,8 +101,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -246,6 +255,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -102,7 +102,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/redhat/foxpass_setup.py
+++ b/linux/redhat/foxpass_setup.py
@@ -95,7 +95,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/redhat/foxpass_setup.py
+++ b/linux/redhat/foxpass_setup.py
@@ -94,8 +94,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -190,6 +199,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -112,7 +112,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -111,8 +111,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -243,6 +252,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -112,8 +112,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -244,6 +253,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -113,7 +113,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -112,7 +112,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -111,8 +111,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -243,6 +252,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -112,7 +112,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -111,8 +111,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -243,6 +252,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -113,7 +113,7 @@ secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
 
-aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
 then
   aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -112,8 +112,17 @@ user="$1"
 secret="%s"
 hostname=`hostname`
 if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
-aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
-aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+
+aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 120"`
+if [ -z "$aws_token" ]
+then
+  aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+else
+  aws_instance_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/instance-id`
+  aws_region_id=`curl -s -q -f -H "X-aws-ec2-metadata-token: ${aws_token}" http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
+fi
+
 %s
 exit $?
 """
@@ -255,6 +264,16 @@ def file_contains(filename, pattern):
 
 
 def is_ec2_host():
+    http = urllib3.PoolManager(timeout=.1)
+    url = 'http://169.254.169.254/latest/api/token'
+    try:
+        r = http.request('PUT', url)
+        return True
+    except Exception:
+        return is_ec2_host_imds_v1_fallback()
+
+
+def is_ec2_host_imds_v1_fallback():
     http = urllib3.PoolManager(timeout=.1)
     url = 'http://169.254.169.254/latest/meta-data/instance-id'
     try:


### PR DESCRIPTION
## Description of the change

AWS IMDS version 2 adds some authentication to the EC2 metadata endpoints to prevent server side request forgery and similar classes of vulnerabilities. By default both v1 and v2 are enabled, however if you disable v1 which is a security improvement, foxpass is unable to allow login because it cannot retrieve the instance id and region as it makes no attempt to authenticate.

This PR attempts to default to using version 2 (it will first make a PUT request the auth endpoint to get a token to use in subsequent requests). If that fails then it will fallback to using version 1, however it is my understanding that all EC2 instances now support v2 and v2 is only unavailable on older elastic beanstalk platforms.

## Type of change
- [ ] Bug fix
- [x] New feature

### Testing

- [x] Testing information has been added - test cases checklist and steps followed for testing.
- [ ] Testing screenshot(s) attached for more information.

For testing, I have run this on Centos 7 and verified that the generated `foxpass_ssh_keys.sh` script works in AWS when both v1 and v2 are available, and when only v2 is enabled.

I copied the code to the other distributions but have not tested them. I skipped the older Ubuntu 12.04 as it uses a different http library which I have no way to easily test and it is end of life.

## Security

- [x] This PR has security related considerations.
