### PR TITLE
foxpass_setup.py: fix: check username with dot in it

### DIFF
--- a/linux/amzn/2.0/foxpass_setup.py
+++ b/linux/amzn/2.0/foxpass_setup.py
@@ -134,7 +134,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -158,7 +158,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/amzn/2014.09/foxpass_setup.py
+++ b/linux/amzn/2014.09/foxpass_setup.py
@@ -93,7 +93,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -117,7 +117,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/amzn/2016.03/foxpass_setup.py
+++ b/linux/amzn/2016.03/foxpass_setup.py
@@ -92,7 +92,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -116,7 +116,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/amzn/2018.03/foxpass_setup.py
+++ b/linux/amzn/2018.03/foxpass_setup.py
@@ -92,7 +92,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -116,7 +116,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/centos/6.5/foxpass_setup.py
+++ b/linux/centos/6.5/foxpass_setup.py
@@ -85,7 +85,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`uname -n`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -109,7 +109,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/centos/7/foxpass_setup.py
+++ b/linux/centos/7/foxpass_setup.py
@@ -133,7 +133,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -157,7 +157,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`uname -n`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/centos/8/foxpass_setup.py
+++ b/linux/centos/8/foxpass_setup.py
@@ -134,7 +134,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -158,7 +158,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`uname -n`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/debian/10/foxpass_setup.py
+++ b/linux/debian/10/foxpass_setup.py
@@ -141,7 +141,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -165,7 +165,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/debian/8/foxpass_setup.py
+++ b/linux/debian/8/foxpass_setup.py
@@ -99,7 +99,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -123,7 +123,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/debian/9/foxpass_setup.py
+++ b/linux/debian/9/foxpass_setup.py
@@ -142,7 +142,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -166,7 +166,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/12.04/foxpass_setup.py
+++ b/linux/ubuntu/12.04/foxpass_setup.py
@@ -102,7 +102,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -117,7 +117,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/14.04/foxpass_setup.py
+++ b/linux/ubuntu/14.04/foxpass_setup.py
@@ -110,7 +110,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -134,7 +134,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/16.04/foxpass_setup.py
+++ b/linux/ubuntu/16.04/foxpass_setup.py
@@ -111,7 +111,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -135,7 +135,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/17.04/foxpass_setup.py
+++ b/linux/ubuntu/17.04/foxpass_setup.py
@@ -110,7 +110,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -134,7 +134,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/18.04/foxpass_setup.py
+++ b/linux/ubuntu/18.04/foxpass_setup.py
@@ -160,7 +160,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -184,7 +184,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/20.04/foxpass_setup.py
+++ b/linux/ubuntu/20.04/foxpass_setup.py
@@ -161,7 +161,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 
 aws_token=`curl -m 10 -s -q -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 30"`
 if [ -z "$aws_token" ]
@@ -185,7 +185,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """

--- a/linux/ubuntu/21.04/foxpass_setup.py
+++ b/linux/ubuntu/21.04/foxpass_setup.py
@@ -116,7 +116,7 @@ def write_foxpass_ssh_keys_script(apis, api_key):
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 aws_instance_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/instance-id`
 aws_region_id=`curl -s -q -f http://169.254.169.254/latest/meta-data/placement/availability-zone | sed 's/.$//'`
 %s
@@ -131,7 +131,7 @@ exit $?
 user="$1"
 secret="%s"
 hostname=`hostname`
-if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi
+if grep -q "^${user/./\\\\.}:" /etc/passwd; then exit; fi
 %s
 exit $?
 """


### PR DESCRIPTION
## Description of the change

in python `backslash` `\` is a special character aka escape symbol
when python writes a file with the `backslash` the next symbol will be escaped

which mean `\\` **=>** `\`

```
Python 3.9.12 (main, Mar 26 2022, 15:52:10)
Type 'copyright', 'credits' or 'license' for more information
IPython 7.31.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: f = open('a_file', "w")

In [2]: f.write('foo\\bar')
Out[2]: 7

In [3]: f.close()

In [4]: cat a_file
foo\bar
```

so `if grep -q "^${user/./\\.}:" /etc/passwd; then exit; fi` turns to `if grep -q "^${user/./\.}:" /etc/passwd; then exit; fi`

This means if a user has a dot in the name for example `foo.bar` it's not gonna be escaped on the bash side.

**test:**
```
cat > passwd_test <<EOF
foo.bar:pwd
foo bar:pwd
foo_bar:pwd
foo-bar:pwd
foo2bar:pwd
EOF

user='foo.bar'
grep "^${user/./\.}:" passwd_test
foo.bar:pwd
foo bar:pwd
foo_bar:pwd
foo-bar:pwd
foo2bar:pwd

grep "^${user/./\\.}:" passwd_test
foo.bar:pwd
```

## Type of change
- [ ] Bug fix

